### PR TITLE
Add FASTTLD_NO_AUTO_UPDATE option

### DIFF
--- a/fasttld/psl.py
+++ b/fasttld/psl.py
@@ -8,6 +8,7 @@
 
 Copyright (c) 2017 Jophy
 """
+import os
 import os.path
 import time
 
@@ -84,6 +85,8 @@ def auto_update():
     This function will update public_suffix_list.dat file every 3 days.
     :return: 
     """
+    if os.environ.get("FASTTLD_NO_AUTO_UPDATE") == "1":
+        return
     need_update = False
     file_path = os.path.dirname(os.path.realpath(__file__)) + "/public_suffix_list.dat"
     if os.path.isfile(file_path):

--- a/fasttld/public_suffix_list.dat
+++ b/fasttld/public_suffix_list.dat
@@ -9,7 +9,7 @@
 
 // ===BEGIN ICANN DOMAINS===
 
-// ac : https://en.wikipedia.org/wiki/.ac
+// ac : http://nic.ac/rules.htm
 ac
 com.ac
 edu.ac
@@ -22,8 +22,7 @@ org.ac
 ad
 nom.ad
 
-// ae : https://en.wikipedia.org/wiki/.ae
-// see also: "Domain Name Eligibility Policy" at http://www.aeda.ae/eng/aepolicy.php
+// ae : https://tdra.gov.ae/en/aeda/ae-policies
 ae
 co.ae
 net.ae
@@ -79,7 +78,6 @@ exchange.aero
 express.aero
 federation.aero
 flight.aero
-freight.aero
 fuel.aero
 gliding.aero
 government.aero
@@ -155,8 +153,13 @@ mil.al
 net.al
 org.al
 
-// am : https://en.wikipedia.org/wiki/.am
+// am : https://www.amnic.net/policy/en/Policy_EN.pdf
 am
+co.am
+com.am
+commune.am
+net.am
+org.am
 
 // ao : https://en.wikipedia.org/wiki/.ao
 // http://www.dns.ao/REGISTR.DOC
@@ -171,17 +174,21 @@ it.ao
 // aq : https://en.wikipedia.org/wiki/.aq
 aq
 
-// ar : https://nic.ar/nic-argentina/normativa-vigente
+// ar : https://nic.ar/es/nic-argentina/normativa
 ar
+bet.ar
 com.ar
+coop.ar
 edu.ar
 gob.ar
 gov.ar
 int.ar
 mil.ar
 musica.ar
+mutual.ar
 net.ar
 org.ar
+senasa.ar
 tur.ar
 
 // arpa : https://en.wikipedia.org/wiki/.arpa
@@ -208,6 +215,7 @@ ac.at
 co.at
 gv.at
 or.at
+sth.ac.at
 
 // au : https://en.wikipedia.org/wiki/.au
 // http://www.auda.org.au/
@@ -235,6 +243,8 @@ vic.au
 wa.au
 // 3LDs
 act.edu.au
+catholic.edu.au
+// eq.edu.au - Removed at the request of the Queensland Department of Education
 nsw.edu.au
 nt.edu.au
 qld.edu.au
@@ -250,6 +260,9 @@ sa.gov.au
 tas.gov.au
 vic.gov.au
 wa.gov.au
+// 4LDs
+// education.tas.edu.au - Removed at the request of the Department of Education Tasmania
+schools.nsw.edu.au
 
 // aw : https://en.wikipedia.org/wiki/.aw
 aw
@@ -381,91 +394,228 @@ gov.bm
 net.bm
 org.bm
 
-// bn : https://en.wikipedia.org/wiki/.bn
-*.bn
+// bn : http://www.bnnic.bn/faqs
+bn
+com.bn
+edu.bn
+gov.bn
+net.bn
+org.bn
 
-// bo : http://www.nic.bo/
+// bo : https://nic.bo/delegacion2015.php#h-1.10
 bo
 com.bo
 edu.bo
-gov.bo
 gob.bo
 int.bo
 org.bo
 net.bo
 mil.bo
 tv.bo
+web.bo
+// Social Domains
+academia.bo
+agro.bo
+arte.bo
+blog.bo
+bolivia.bo
+ciencia.bo
+cooperativa.bo
+democracia.bo
+deporte.bo
+ecologia.bo
+economia.bo
+empresa.bo
+indigena.bo
+industria.bo
+info.bo
+medicina.bo
+movimiento.bo
+musica.bo
+natural.bo
+nombre.bo
+noticias.bo
+patria.bo
+politica.bo
+profesional.bo
+plurinacional.bo
+pueblo.bo
+revista.bo
+salud.bo
+tecnologia.bo
+tksat.bo
+transporte.bo
+wiki.bo
 
 // br : http://registro.br/dominio/categoria.html
 // Submitted by registry <fneves@registro.br>
 br
+9guacu.br
+abc.br
 adm.br
 adv.br
 agr.br
+aju.br
 am.br
+anani.br
+aparecida.br
+app.br
 arq.br
 art.br
 ato.br
 b.br
+barueri.br
+belem.br
+bhz.br
+bib.br
 bio.br
 blog.br
 bmd.br
+boavista.br
+bsb.br
+campinagrande.br
+campinas.br
+caxias.br
 cim.br
 cng.br
 cnt.br
 com.br
+contagem.br
 coop.br
+coz.br
+cri.br
+cuiaba.br
+curitiba.br
+def.br
+des.br
+det.br
+dev.br
 ecn.br
 eco.br
 edu.br
 emp.br
+enf.br
 eng.br
 esp.br
 etc.br
 eti.br
 far.br
+feira.br
 flog.br
+floripa.br
 fm.br
 fnd.br
+fortal.br
 fot.br
+foz.br
 fst.br
 g12.br
+geo.br
 ggf.br
+goiania.br
 gov.br
+// gov.br 26 states + df https://en.wikipedia.org/wiki/States_of_Brazil
+ac.gov.br
+al.gov.br
+am.gov.br
+ap.gov.br
+ba.gov.br
+ce.gov.br
+df.gov.br
+es.gov.br
+go.gov.br
+ma.gov.br
+mg.gov.br
+ms.gov.br
+mt.gov.br
+pa.gov.br
+pb.gov.br
+pe.gov.br
+pi.gov.br
+pr.gov.br
+rj.gov.br
+rn.gov.br
+ro.gov.br
+rr.gov.br
+rs.gov.br
+sc.gov.br
+se.gov.br
+sp.gov.br
+to.gov.br
+gru.br
 imb.br
 ind.br
 inf.br
+jab.br
+jampa.br
+jdf.br
+joinville.br
 jor.br
 jus.br
 leg.br
 lel.br
+log.br
+londrina.br
+macapa.br
+maceio.br
+manaus.br
+maringa.br
 mat.br
 med.br
 mil.br
+morena.br
 mp.br
 mus.br
+natal.br
 net.br
+niteroi.br
 *.nom.br
 not.br
 ntr.br
 odo.br
+ong.br
 org.br
+osasco.br
+palmas.br
+poa.br
 ppg.br
 pro.br
 psc.br
 psi.br
+pvh.br
 qsl.br
 radio.br
 rec.br
+recife.br
+rep.br
+ribeirao.br
+rio.br
+riobranco.br
+riopreto.br
+salvador.br
+sampa.br
+santamaria.br
+santoandre.br
+saobernardo.br
+saogonca.br
+seg.br
+sjc.br
 slg.br
+slz.br
+sorocaba.br
 srv.br
 taxi.br
+tc.br
+tec.br
 teo.br
+the.br
 tmp.br
 trd.br
 tur.br
 tv.br
+udi.br
 vet.br
+vix.br
 vlog.br
 wiki.br
 zlg.br
@@ -584,11 +734,12 @@ gouv.ci
 *.ck
 !www.ck
 
-// cl : https://en.wikipedia.org/wiki/.cl
+// cl : https://www.nic.cl
+// Confirmed by .CL registry <hsalgado@nic.cl>
 cl
-gov.cl
-gob.cl
 co.cl
+gob.cl
+gov.cl
 mil.cl
 
 // cm : https://en.wikipedia.org/wiki/.cm plus bug 981927
@@ -690,7 +841,13 @@ gov.cu
 inf.cu
 
 // cv : https://en.wikipedia.org/wiki/.cv
+// cv : http://www.dns.cv/tldcv_portal/do?com=DS;5446457100;111;+PAGE(4000018)+K-CAT-CODIGO(RDOM)+RCNT(100); <- registration rules
 cv
+com.cv
+edu.cv
+int.cv
+nome.cv
+org.cv
 
 // cw : http://www.una.cw/cw_registry/
 // Confirmed by registry <registry@una.net> 2013-03-26
@@ -707,6 +864,7 @@ gov.cx
 
 // cy : http://www.nic.cy/
 // Submitted by registry Panayiotou Fotia <cydns@ucy.ac.cy>
+// namespace policies URL https://www.nic.cy/portal//sites/default/files/symfonia_gia_eggrafi.pdf
 cy
 ac.cy
 biz.cy
@@ -714,10 +872,9 @@ com.cy
 ekloges.cy
 gov.cy
 ltd.cy
-name.cy
+mil.cy
 net.cy
 org.cy
-parliament.cy
 press.cy
 pro.cy
 tm.cy
@@ -758,16 +915,18 @@ org.do
 sld.do
 web.do
 
-// dz : https://en.wikipedia.org/wiki/.dz
+// dz : http://www.nic.dz/images/pdf_nic/charte.pdf
 dz
+art.dz
+asso.dz
 com.dz
+edu.dz
+gov.dz
 org.dz
 net.dz
-gov.dz
-edu.dz
-asso.dz
 pol.dz
-art.dz
+soc.dz
+tm.dz
 
 // ec : http://www.nic.ec/reg/paso1.asp
 // Submitted by registry <vabboud@nic.ec>
@@ -847,30 +1006,44 @@ fi
 // TODO: Check for updates (expected to be phased out around Q1/2009)
 aland.fi
 
-// fj : https://en.wikipedia.org/wiki/.fj
-*.fj
+// fj : http://domains.fj/
+// Submitted by registry <garth.miller@cocca.org.nz> 2020-02-11
+fj
+ac.fj
+biz.fj
+com.fj
+gov.fj
+info.fj
+mil.fj
+name.fj
+net.fj
+org.fj
+pro.fj
 
 // fk : https://en.wikipedia.org/wiki/.fk
 *.fk
 
 // fm : https://en.wikipedia.org/wiki/.fm
+com.fm
+edu.fm
+net.fm
+org.fm
 fm
 
 // fo : https://en.wikipedia.org/wiki/.fo
 fo
 
 // fr : http://www.afnic.fr/
-// domaines descriptifs : http://www.afnic.fr/obtenir/chartes/nommage-fr/annexe-descriptifs
+// domaines descriptifs : https://www.afnic.fr/medias/documents/Cadre_legal/Afnic_Naming_Policy_12122016_VEN.pdf
 fr
-com.fr
 asso.fr
+com.fr
+gouv.fr
 nom.fr
 prd.fr
-presse.fr
 tm.fr
-// domaines sectoriels : http://www.afnic.fr/obtenir/chartes/nommage-fr/annexe-sectoriels
+// domaines sectoriels : https://www.afnic.fr/en/products-and-services/the-fr-tld/sector-based-fr-domains-4.html
 aeroport.fr
-assedic.fr
 avocat.fr
 avoues.fr
 cci.fr
@@ -878,7 +1051,6 @@ chambagri.fr
 chirurgiens-dentistes.fr
 experts-comptables.fr
 geometre-expert.fr
-gouv.fr
 greta.fr
 huissier-justice.fr
 medecin.fr
@@ -895,6 +1067,8 @@ ga
 gb
 
 // gd : https://en.wikipedia.org/wiki/.gd
+edu.gd
+gov.gd
 gd
 
 // ge : http://www.nic.net.ge/policy_en.pdf
@@ -986,7 +1160,7 @@ gov.gr
 // gs : https://en.wikipedia.org/wiki/.gs
 gs
 
-// gt : http://www.gt/politicas_de_registro.html
+// gt : https://www.gt/sitio/registration_policy.php?lang=en
 gt
 com.gt
 edu.gt
@@ -996,10 +1170,21 @@ mil.gt
 net.gt
 org.gt
 
-// gu : http://gadao.gov.gu/registration.txt
-*.gu
+// gu : http://gadao.gov.gu/register.html
+// University of Guam : https://www.uog.edu
+// Submitted by uognoc@triton.uog.edu
+gu
+com.gu
+edu.gu
+gov.gu
+guam.gu
+info.gu
+net.gu
+org.gu
+web.gu
 
 // gw : https://en.wikipedia.org/wiki/.gw
+// gw : https://nic.gw/regras/
 gw
 
 // gy : https://en.wikipedia.org/wiki/.gy
@@ -1012,7 +1197,7 @@ gov.gy
 net.gy
 org.gy
 
-// hk : https://www.hkdnr.hk
+// hk : https://www.hkirc.hk
 // Submitted by registry <hk.tech@hkirc.hk>
 hk
 com.hk
@@ -1111,7 +1296,7 @@ tozsde.hu
 utazas.hu
 video.hu
 
-// id : https://register.pandi.or.id/
+// id : https://pandi.id/en/domain/registration-requirements/
 id
 ac.id
 biz.id
@@ -1122,6 +1307,7 @@ mil.id
 my.id
 net.id
 or.id
+ponpes.id
 sch.id
 web.id
 
@@ -1179,7 +1365,7 @@ info
 int
 eu.int
 
-// io : http://www.nic.io/rules.html
+// io : http://www.nic.io/rules.htm
 // list of other 2nd level tlds ?
 io
 com.io
@@ -1223,10 +1409,8 @@ int.is
 it
 gov.it
 edu.it
-// Reserved geo-names:
-// http://www.nic.it/documenti/regolamenti-e-linee-guida/regolamento-assegnazione-versione-6.0.pdf
-// There is also a list of reserved geo-names corresponding to Italian municipalities
-// http://www.nic.it/documenti/appendice-c.pdf, but it is not included here.
+// Reserved geo-names (regions and provinces):
+// https://www.nic.it/sites/default/files/archivio/docs/Regulation_assignation_v7.1.pdf
 // Regions
 abr.it
 abruzzo.it
@@ -1280,6 +1464,12 @@ sicily.it
 taa.it
 tos.it
 toscana.it
+trentin-sud-tirol.it
+trentin-süd-tirol.it
+trentin-sudtirol.it
+trentin-südtirol.it
+trentin-sued-tirol.it
+trentin-suedtirol.it
 trentino-a-adige.it
 trentino-aadige.it
 trentino-alto-adige.it
@@ -1287,9 +1477,12 @@ trentino-altoadige.it
 trentino-s-tirol.it
 trentino-stirol.it
 trentino-sud-tirol.it
+trentino-süd-tirol.it
 trentino-sudtirol.it
+trentino-südtirol.it
 trentino-sued-tirol.it
 trentino-suedtirol.it
+trentino.it
 trentinoa-adige.it
 trentinoaadige.it
 trentinoalto-adige.it
@@ -1297,9 +1490,17 @@ trentinoaltoadige.it
 trentinos-tirol.it
 trentinostirol.it
 trentinosud-tirol.it
+trentinosüd-tirol.it
 trentinosudtirol.it
+trentinosüdtirol.it
 trentinosued-tirol.it
 trentinosuedtirol.it
+trentinsud-tirol.it
+trentinsüd-tirol.it
+trentinsudtirol.it
+trentinsüdtirol.it
+trentinsued-tirol.it
+trentinsuedtirol.it
 tuscany.it
 umb.it
 umbria.it
@@ -1314,7 +1515,13 @@ valleaosta.it
 valled-aosta.it
 valledaosta.it
 vallee-aoste.it
+vallée-aoste.it
+vallee-d-aoste.it
+vallée-d-aoste.it
 valleeaoste.it
+valléeaoste.it
+valleedaoste.it
+valléedaoste.it
 vao.it
 vda.it
 ven.it
@@ -1347,6 +1554,9 @@ at.it
 av.it
 avellino.it
 ba.it
+balsan-sudtirol.it
+balsan-südtirol.it
+balsan-suedtirol.it
 balsan.it
 bari.it
 barletta-trani-andria.it
@@ -1361,13 +1571,21 @@ bl.it
 bn.it
 bo.it
 bologna.it
+bolzano-altoadige.it
 bolzano.it
+bozen-sudtirol.it
+bozen-südtirol.it
+bozen-suedtirol.it
 bozen.it
 br.it
 brescia.it
 brindisi.it
 bs.it
 bt.it
+bulsan-sudtirol.it
+bulsan-südtirol.it
+bulsan-suedtirol.it
+bulsan.it
 bz.it
 ca.it
 cagliari.it
@@ -1385,7 +1603,9 @@ catanzaro.it
 cb.it
 ce.it
 cesena-forli.it
+cesena-forlì.it
 cesenaforli.it
+cesenaforlì.it
 ch.it
 chieti.it
 ci.it
@@ -1416,7 +1636,9 @@ florence.it
 fm.it
 foggia.it
 forli-cesena.it
+forlì-cesena.it
 forlicesena.it
+forlìcesena.it
 fr.it
 frosinone.it
 ge.it
@@ -1547,6 +1769,7 @@ sp.it
 sr.it
 ss.it
 suedtirol.it
+südtirol.it
 sv.it
 ta.it
 taranto.it
@@ -1565,7 +1788,6 @@ trani-barletta-andria.it
 traniandriabarletta.it
 tranibarlettaandria.it
 trapani.it
-trentino.it
 trento.it
 treviso.it
 trieste.it
@@ -3420,8 +3642,17 @@ uenohara.yamanashi.jp
 yamanakako.yamanashi.jp
 yamanashi.yamanashi.jp
 
-// ke : http://www.kenic.or.ke/index.php?option=com_content&task=view&id=117&Itemid=145
-*.ke
+// ke : http://www.kenic.or.ke/index.php/en/ke-domains/ke-domains
+ke
+ac.ke
+co.ke
+go.ke
+info.ke
+me.ke
+mobi.ke
+ne.ke
+or.ke
+sc.ke
 
 // kg : http://www.domain.kg/dmn_n.html
 kg
@@ -3519,17 +3750,24 @@ jeonnam.kr
 seoul.kr
 ulsan.kr
 
-// kw : https://en.wikipedia.org/wiki/.kw
-*.kw
+// kw : https://www.nic.kw/policies/
+// Confirmed by registry <nic.tech@citra.gov.kw>
+kw
+com.kw
+edu.kw
+emb.kw
+gov.kw
+ind.kw
+net.kw
+org.kw
 
 // ky : http://www.icta.ky/da_ky_reg_dom.php
 // Confirmed by registry <kysupport@perimeterusa.com> 2008-06-17
 ky
-edu.ky
-gov.ky
 com.ky
-org.ky
+edu.ky
 net.ky
+org.ky
 
 // kz : https://en.wikipedia.org/wiki/.kz
 // see also: http://www.nic.kz/rules/index.jsp
@@ -3575,7 +3813,7 @@ gov.lc
 // li : https://en.wikipedia.org/wiki/.li
 li
 
-// lk : http://www.nic.lk/seclevpr.html
+// lk : https://www.nic.lk/index.php/domain-registration/lk-domain-naming-structure
 lk
 gov.lk
 sch.lk
@@ -3602,10 +3840,18 @@ gov.lr
 org.lr
 net.lr
 
-// ls : https://en.wikipedia.org/wiki/.ls
+// ls : http://www.nic.ls/
+// Confirmed by registry <lsadmin@nic.ls>
 ls
+ac.ls
+biz.ls
 co.ls
+edu.ls
+gov.ls
+info.ls
+net.ls
 org.ls
+sc.ls
 
 // lt : https://en.wikipedia.org/wiki/.lt
 lt
@@ -4134,8 +4380,6 @@ niepce.museum
 norfolk.museum
 north.museum
 nrw.museum
-nuernberg.museum
-nuremberg.museum
 nyc.museum
 nyny.museum
 oceanographic.museum
@@ -4358,15 +4602,17 @@ gob.mx
 edu.mx
 net.mx
 
-// my : http://www.mynic.net.my/
+// my : http://www.mynic.my/
+// Available strings: https://mynic.my/resources/domains/buying-a-domain/
 my
+biz.my
 com.my
-net.my
-org.my
-gov.my
 edu.my
+gov.my
 mil.my
 name.my
+net.my
+org.my
 
 // mz : http://www.uem.mz/
 // Submitted by registry <antonio@uem.mz>
@@ -4407,6 +4653,7 @@ name
 // nc : http://www.cctld.nc/
 nc
 asso.nc
+nom.nc
 
 // ne : https://en.wikipedia.org/wiki/.ne
 ne
@@ -4462,16 +4709,13 @@ web.ni
 //      ccTLD for the Netherlands
 nl
 
-// BV.nl will be a registry for dutch BV's (besloten vennootschap)
-bv.nl
-
-// no : http://www.norid.no/regelverk/index.en.html
-// The Norwegian registry has declined to notify us of updates. The web pages
-// referenced below are the official source of the data. There is also an
-// announce mailing list:
-// https://postlister.uninett.no/sympa/info/norid-diskusjon
+// no : https://www.norid.no/en/om-domenenavn/regelverk-for-no/
+// Norid geographical second level domains : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-b/
+// Norid category second level domains : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-c/
+// Norid category second-level domains managed by parties other than Norid : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-d/
+// RSS feed: https://teknisk.norid.no/en/feed/
 no
-// Norid generic domains : http://www.norid.no/regelverk/vedlegg-c.en.html
+// Norid category second level domains : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-c/
 fhs.no
 vgs.no
 fylkesbibl.no
@@ -4479,13 +4723,13 @@ folkebibl.no
 museum.no
 idrett.no
 priv.no
-// Non-Norid generic domains : http://www.norid.no/regelverk/vedlegg-d.en.html
+// Norid category second-level domains managed by parties other than Norid : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-d/
 mil.no
 stat.no
 dep.no
 kommune.no
 herad.no
-// no geographical names : http://www.norid.no/regelverk/vedlegg-b.en.html
+// Norid geographical second level domains : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-b/
 // counties
 aa.no
 ah.no
@@ -5614,7 +5858,7 @@ com.ps
 org.ps
 net.ps
 
-// pt : http://online.dns.pt/dns/start_dns
+// pt : https://www.dns.pt/en/domain/pt-terms-and-conditions-registration-rules/
 pt
 net.pt
 gov.pt
@@ -5685,26 +5929,19 @@ gov.rs
 in.rs
 org.rs
 
-// ru : https://cctld.ru/en/domains/domens_ru/reserved/
+// ru : https://cctld.ru/files/pdf/docs/en/rules_ru-rf.pdf
+// Submitted by George Georgievsky <gug@cctld.ru>
 ru
-ac.ru
-edu.ru
-gov.ru
-int.ru
-mil.ru
-test.ru
 
-// rw : http://www.nic.rw/cgi-bin/policy.pl
+// rw : https://www.ricta.org.rw/sites/default/files/resources/registry_registrar_contract_0.pdf
 rw
-gov.rw
-net.rw
-edu.rw
 ac.rw
-com.rw
 co.rw
-int.rw
+coop.rw
+gov.rw
 mil.rw
-gouv.rw
+net.rw
+org.rw
 
 // sa : http://www.nic.net.sa/
 sa
@@ -5798,7 +6035,7 @@ gov.sg
 edu.sg
 per.sg
 
-// sh : http://www.nic.sh/registrar.html
+// sh : http://nic.sh/rules.htm
 sh
 com.sh
 net.sh
@@ -5839,14 +6076,29 @@ org.sn
 perso.sn
 univ.sn
 
-// so : http://www.soregistry.com/
+// so : http://sonic.so/policies/
 so
 com.so
+edu.so
+gov.so
+me.so
 net.so
 org.so
 
 // sr : https://en.wikipedia.org/wiki/.sr
 sr
+
+// ss : https://registry.nic.ss/
+// Submitted by registry <technical@nic.ss>
+ss
+biz.ss
+com.ss
+edu.ss
+gov.ss
+me.ss
+net.ss
+org.ss
+sch.ss
 
 // st : http://www.nic.st/html/policyrules/
 st
@@ -5855,7 +6107,6 @@ com.st
 consulado.st
 edu.st
 embaixada.st
-gov.st
 mil.st
 net.st
 org.st
@@ -5960,29 +6211,22 @@ gov.tm
 mil.tm
 edu.tm
 
-// tn : https://en.wikipedia.org/wiki/.tn
-// http://whois.ati.tn/
+// tn : http://www.registre.tn/fr/
+// https://whois.ati.tn/
 tn
 com.tn
 ens.tn
 fin.tn
 gov.tn
 ind.tn
+info.tn
 intl.tn
+mincom.tn
 nat.tn
 net.tn
 org.tn
-info.tn
 perso.tn
 tourism.tn
-edunet.tn
-rnrt.tn
-rns.tn
-rnu.tn
-mincom.tn
-agrinet.tn
-defense.tn
-turen.tn
 
 // to : https://en.wikipedia.org/wiki/.to
 // Submitted by registry <egullich@colo.to>
@@ -5994,39 +6238,35 @@ org.to
 edu.to
 mil.to
 
-// subTLDs: https://www.nic.tr/forms/eng/policies.pdf
-//     and: https://www.nic.tr/forms/politikalar.pdf
-// Submitted by <mehmetgurevin@gmail.com>
+// tr : https://nic.tr/
+// https://nic.tr/forms/eng/policies.pdf
+// https://nic.tr/index.php?USRACTN=PRICELST
 tr
-com.tr
-info.tr
-biz.tr
-net.tr
-org.tr
-web.tr
-gen.tr
-tv.tr
 av.tr
-dr.tr
 bbs.tr
-name.tr
-tel.tr
-gov.tr
 bel.tr
-pol.tr
+biz.tr
+com.tr
+dr.tr
+edu.tr
+gen.tr
+gov.tr
+info.tr
 mil.tr
 k12.tr
-edu.tr
 kep.tr
-
+name.tr
+net.tr
+org.tr
+pol.tr
+tel.tr
+tsk.tr
+tv.tr
+web.tr
 // Used by Northern Cyprus
 nc.tr
-
 // Used by government agencies of Northern Cyprus
 gov.nc.tr
-
-// travel : https://en.wikipedia.org/wiki/.travel
-travel
 
 // tt : http://www.nic.tt/
 tt
@@ -6111,7 +6351,6 @@ cv.ua
 dn.ua
 dnepropetrovsk.ua
 dnipropetrovsk.ua
-dominic.ua
 donetsk.ua
 dp.ua
 if.ua
@@ -6305,7 +6544,7 @@ k12.ok.us
 k12.or.us
 k12.pa.us
 k12.pr.us
-k12.ri.us
+// k12.ri.us  Removed at request of Kim Cournoyer <netsupport@staff.ri.net>
 k12.sc.us
 // k12.sd.us  Bug 934131 - Removed at request of James Booze <James.Booze@k12.sd.us>
 k12.tn.us
@@ -6435,6 +6674,17 @@ lib.wy.us
 pvt.k12.ma.us
 chtr.k12.ma.us
 paroch.k12.ma.us
+// Merit Network, Inc. maintains the registry for =~ /(k12|cc|lib).mi.us/ and the following
+//    see also: http://domreg.merit.edu
+//    see also: whois -h whois.domreg.merit.edu help
+ann-arbor.mi.us
+cog.mi.us
+dst.mi.us
+eaton.mi.us
+gen.mi.us
+mus.mi.us
+tec.mi.us
+washtenaw.mi.us
 
 // uy : http://www.nic.org.uy/
 uy
@@ -6466,9 +6716,10 @@ mil.vc
 edu.vc
 
 // ve : https://registro.nic.ve/
-// Submitted by registry
+// Submitted by registry nic@nic.ve and nicve@conatel.gob.ve
 ve
 arts.ve
+bib.ve
 co.ve
 com.ve
 e12.ve
@@ -6480,7 +6731,9 @@ info.ve
 int.ve
 mil.ve
 net.ve
+nom.ve
 org.ve
+rar.ve
 rec.ve
 store.ve
 tec.ve
@@ -6556,6 +6809,12 @@ yt
 // xn--54b7fta0cc ("Bangla", Bangla) : BD
 বাংলা
 
+// xn--90ae ("bg", Bulgarian) : BG
+бг
+
+// xn--mgbcpq6gpa1a ("albahrain", Arabic) : BH
+البحرين
+
 // xn--90ais ("bel", Belarusian/Russian Cyrillic) : BY
 // Operated by .by registry
 бел
@@ -6578,7 +6837,15 @@ yt
 مصر
 
 // xn--e1a4c ("eu", Cyrillic) : EU
+// https://eurid.eu
 ею
+
+// xn--qxa6a ("eu", Greek) : EU
+// https://eurid.eu
+ευ
+
+// xn--mgbah1a3hjkrd ("Mauritania", Arabic) : MR
+موريتانيا
 
 // xn--node ("ge", Georgian Mkhedruli) : GE
 გე
@@ -6588,12 +6855,52 @@ yt
 ελ
 
 // xn--j6w193g ("Hong Kong", Chinese) : HK
-// https://www2.hkirc.hk/register/rules.jsp
+// https://www.hkirc.hk
+// Submitted by registry <hk.tech@hkirc.hk>
+// https://www.hkirc.hk/content.jsp?id=30#!/34
 香港
+公司.香港
+教育.香港
+政府.香港
+個人.香港
+網絡.香港
+組織.香港
+
+// xn--2scrj9c ("Bharat", Kannada) : IN
+// India
+ಭಾರತ
+
+// xn--3hcrj9c ("Bharat", Oriya) : IN
+// India
+ଭାରତ
+
+// xn--45br5cyl ("Bharatam", Assamese) : IN
+// India
+ভাৰত
+
+// xn--h2breg3eve ("Bharatam", Sanskrit) : IN
+// India
+भारतम्
+
+// xn--h2brj9c8c ("Bharot", Santali) : IN
+// India
+भारोत
+
+// xn--mgbgu82a ("Bharat", Sindhi) : IN
+// India
+ڀارت
+
+// xn--rvc1e0am3e ("Bharatam", Malayalam) : IN
+// India
+ഭാരതം
 
 // xn--h2brj9c ("Bharat", Devanagari) : IN
 // India
 भारत
+
+// xn--mgbbh1a ("Bharat", Kashmiri) : IN
+// India
+بارت
 
 // xn--mgbbh1a71e ("Bharat", Arabic) : IN
 // India
@@ -6640,12 +6947,15 @@ yt
 // xn--80ao21a ("Kaz", Kazakh) : KZ
 қаз
 
+// xn--q7ce6a ("Lao", Lao) : LA
+ລາວ
+
 // xn--fzc2c9e2c ("Lanka", Sinhalese-Sinhala) : LK
-// http://nic.lk
+// https://nic.lk
 ලංකා
 
 // xn--xkc2al3hye2a ("Ilangai", Tamil) : LK
-// http://nic.lk
+// https://nic.lk
 இலங்கை
 
 // xn--mgbc0a9azcg ("Morocco/al-Maghrib", Arabic) : MA
@@ -6693,7 +7003,8 @@ yt
 ак.срб
 
 // xn--p1ai ("rf", Russian-Cyrillic) : RU
-// http://www.cctld.ru/en/docs/rulesrf.php
+// https://cctld.ru/files/pdf/docs/en/rules_ru-rf.pdf
+// Submitted by George Georgievsky <gug@cctld.ru>
 рф
 
 // xn--wgbl6a ("Qatar", Arabic) : QA
@@ -6764,9 +7075,15 @@ yt
 xxx
 
 // ye : http://www.y.net.ye/services/domain_name.htm
-*.ye
+ye
+com.ye
+edu.ye
+gov.ye
+net.ye
+mil.ye
+org.ye
 
-// za : http://www.zadna.org.za/content/page/domain-information
+// za : https://www.zadna.org.za/content/page/domain-information/
 ac.za
 agric.za
 alt.za
@@ -6778,6 +7095,7 @@ law.za
 mil.za
 net.za
 ngo.za
+nic.za
 nis.za
 nom.za
 org.za
@@ -6809,8 +7127,11 @@ gov.zw
 mil.zw
 org.zw
 
-// List of new gTLDs imported from https://newgtlds.icann.org/newgtlds.csv on 2017-02-23T00:46:09Z
 
+// newGTLDs
+
+// List of new gTLDs imported from https://www.icann.org/resources/registries/gtlds/v2/gtlds.json on 2022-04-14T15:15:34Z
+// This list is auto-generated, don't edit it manually.
 // aaa : 2015-02-26 American Automobile Association, Inc.
 aaa
 
@@ -6835,13 +7156,13 @@ abc
 // able : 2015-06-25 Able Inc.
 able
 
-// abogado : 2014-04-24 Top Level Domain Holdings Limited
+// abogado : 2014-04-24 Registry Services, LLC
 abogado
 
 // abudhabi : 2015-07-30 Abu Dhabi Systems and Information Centre
 abudhabi
 
-// academy : 2013-11-07 Half Oaks, LLC
+// academy : 2013-11-07 Binky Moon, LLC
 academy
 
 // accenture : 2014-08-15 Accenture plc
@@ -6850,16 +7171,13 @@ accenture
 // accountant : 2014-11-20 dot Accountant Limited
 accountant
 
-// accountants : 2014-03-20 Knob Town, LLC
+// accountants : 2014-03-20 Binky Moon, LLC
 accountants
 
 // aco : 2015-01-08 ACO Severin Ahlmann GmbH & Co. KG
 aco
 
-// active : 2014-05-01 The Active Network, Inc
-active
-
-// actor : 2013-12-12 United TLD Holdco Ltd.
+// actor : 2013-12-12 Dog Beach, LLC
 actor
 
 // adac : 2015-07-16 Allgemeiner Deutscher Automobil-Club e.V. (ADAC)
@@ -6877,9 +7195,6 @@ aeg
 // aetna : 2015-05-21 Aetna Life Insurance Company
 aetna
 
-// afamilycompany : 2015-07-23 Johnson Shareholdings, Inc.
-afamilycompany
-
 // afl : 2014-10-02 Australian Football League
 afl
 
@@ -6889,19 +7204,16 @@ africa
 // agakhan : 2015-04-23 Fondation Aga Khan (Aga Khan Foundation)
 agakhan
 
-// agency : 2013-11-14 Steel Falls, LLC
+// agency : 2013-11-14 Binky Moon, LLC
 agency
 
 // aig : 2014-12-18 American International Group, Inc.
 aig
 
-// aigo : 2015-08-06 aigo Digital Technology Co,Ltd.
-aigo
-
 // airbus : 2015-07-30 Airbus S.A.S.
 airbus
 
-// airforce : 2014-03-06 United TLD Holdco Ltd.
+// airforce : 2014-03-06 Dog Beach, LLC
 airforce
 
 // airtel : 2014-10-24 Bharti Airtel Limited
@@ -6928,11 +7240,14 @@ allstate
 // ally : 2015-06-18 Ally Financial Inc.
 ally
 
-// alsace : 2014-07-02 REGION D ALSACE
+// alsace : 2014-07-02 Region Grand Est
 alsace
 
 // alstom : 2015-07-30 ALSTOM
 alstom
+
+// amazon : 2019-12-19 Amazon Registry Services, Inc.
+amazon
 
 // americanexpress : 2015-07-31 American Express Travel Related Services Company, Inc.
 americanexpress
@@ -6958,16 +7273,16 @@ analytics
 // android : 2014-08-07 Charleston Road Registry Inc.
 android
 
-// anquan : 2015-01-08 QIHOO 360 TECHNOLOGY CO. LTD.
+// anquan : 2015-01-08 Beijing Qihu Keji Co., Ltd.
 anquan
 
 // anz : 2015-07-31 Australia and New Zealand Banking Group Limited
 anz
 
-// aol : 2015-09-17 AOL Inc.
+// aol : 2015-09-17 Oath Inc.
 aol
 
-// apartments : 2014-12-11 June Maple, LLC
+// apartments : 2014-12-11 Binky Moon, LLC
 apartments
 
 // app : 2015-05-14 Charleston Road Registry Inc.
@@ -6985,10 +7300,10 @@ arab
 // aramco : 2014-11-20 Aramco Services Company
 aramco
 
-// archi : 2014-02-06 STARTING DOT LIMITED
+// archi : 2014-02-06 Afilias Limited
 archi
 
-// army : 2014-03-06 United TLD Holdco Ltd.
+// army : 2014-03-06 Dog Beach, LLC
 army
 
 // art : 2016-03-24 UK Creative Ideas Limited
@@ -7000,52 +7315,52 @@ arte
 // asda : 2015-07-31 Wal-Mart Stores, Inc.
 asda
 
-// associates : 2014-03-06 Baxter Hill, LLC
+// associates : 2014-03-06 Binky Moon, LLC
 associates
 
 // athleta : 2015-07-30 The Gap, Inc.
 athleta
 
-// attorney : 2014-03-20
+// attorney : 2014-03-20 Dog Beach, LLC
 attorney
 
-// auction : 2014-03-20
+// auction : 2014-03-20 Dog Beach, LLC
 auction
 
 // audi : 2015-05-21 AUDI Aktiengesellschaft
 audi
 
-// audible : 2015-06-25 Amazon EU S.à r.l.
+// audible : 2015-06-25 Amazon Registry Services, Inc.
 audible
 
-// audio : 2014-03-20 Uniregistry, Corp.
+// audio : 2014-03-20 XYZ.COM LLC
 audio
 
 // auspost : 2015-08-13 Australian Postal Corporation
 auspost
 
-// author : 2014-12-18 Amazon EU S.à r.l.
+// author : 2014-12-18 Amazon Registry Services, Inc.
 author
 
-// auto : 2014-11-13
+// auto : 2014-11-13 XYZ.COM LLC
 auto
 
-// autos : 2014-01-09 DERAutos, LLC
+// autos : 2014-01-09 XYZ.COM LLC
 autos
 
-// avianca : 2015-01-08 Aerovias del Continente Americano S.A. Avianca
+// avianca : 2015-01-08 Avianca Holdings S.A.
 avianca
 
-// aws : 2015-06-25 Amazon EU S.à r.l.
+// aws : 2015-06-25 AWS Registry LLC
 aws
 
-// axa : 2013-12-19 AXA SA
+// axa : 2013-12-19 AXA Group Operations SAS
 axa
 
 // azure : 2014-12-18 Microsoft Corporation
 azure
 
-// baby : 2015-04-09 Johnson & Johnson Services, Inc.
+// baby : 2015-04-09 XYZ.COM LLC
 baby
 
 // baidu : 2015-01-08 Baidu, Inc.
@@ -7057,7 +7372,7 @@ banamex
 // bananarepublic : 2015-07-31 The Gap, Inc.
 bananarepublic
 
-// band : 2014-06-12
+// band : 2014-06-12 Dog Beach, LLC
 band
 
 // bank : 2014-09-25 fTLD Registry Services LLC
@@ -7078,7 +7393,7 @@ barclays
 // barefoot : 2015-06-11 Gallo Vineyards, Inc.
 barefoot
 
-// bargains : 2013-11-14 Half Hallow, LLC
+// bargains : 2013-11-14 Binky Moon, LLC
 bargains
 
 // baseball : 2015-10-29 MLB Advanced Media DH, LLC
@@ -7111,10 +7426,10 @@ bcn
 // beats : 2015-05-14 Beats Electronics, LLC
 beats
 
-// beauty : 2015-12-03 L'Oréal
+// beauty : 2015-12-03 XYZ.COM LLC
 beauty
 
-// beer : 2014-01-09 Top Level Domain Holdings Limited
+// beer : 2014-01-09 Registry Services, LLC
 beer
 
 // bentley : 2014-12-18 Bentley Motors Limited
@@ -7129,7 +7444,7 @@ best
 // bestbuy : 2015-07-31 BBY Solutions, Inc.
 bestbuy
 
-// bet : 2015-05-07 Afilias plc
+// bet : 2015-05-07 Afilias Limited
 bet
 
 // bharti : 2014-01-09 Bharti Enterprises (Holding) Private Limited
@@ -7141,31 +7456,28 @@ bible
 // bid : 2013-12-19 dot Bid Limited
 bid
 
-// bike : 2013-08-27 Grand Hollow, LLC
+// bike : 2013-08-27 Binky Moon, LLC
 bike
 
 // bing : 2014-12-18 Microsoft Corporation
 bing
 
-// bingo : 2014-12-04 Sand Cedar, LLC
+// bingo : 2014-12-04 Binky Moon, LLC
 bingo
 
-// bio : 2014-03-06 STARTING DOT LIMITED
+// bio : 2014-03-06 Afilias Limited
 bio
 
 // black : 2014-01-16 Afilias Limited
 black
 
-// blackfriday : 2014-01-16 Uniregistry, Corp.
+// blackfriday : 2014-01-16 Registry Services, LLC
 blackfriday
-
-// blanco : 2015-07-16 BLANCO GmbH + Co KG
-blanco
 
 // blockbuster : 2015-07-30 Dish DBS Corporation
 blockbuster
 
-// blog : 2015-05-14
+// blog : 2015-05-14 Knock Knock WHOIS There, LLC
 blog
 
 // bloomberg : 2014-07-17 Bloomberg IP Holdings LLC
@@ -7180,38 +7492,32 @@ bms
 // bmw : 2014-01-09 Bayerische Motoren Werke Aktiengesellschaft
 bmw
 
-// bnl : 2014-07-24 Banca Nazionale del Lavoro
-bnl
-
 // bnpparibas : 2014-05-29 BNP Paribas
 bnpparibas
 
-// boats : 2014-12-04 DERBoats, LLC
+// boats : 2014-12-04 XYZ.COM LLC
 boats
 
 // boehringer : 2015-07-09 Boehringer Ingelheim International GmbH
 boehringer
 
-// bofa : 2015-07-31 NMS Services, Inc.
+// bofa : 2015-07-31 Bank of America Corporation
 bofa
 
 // bom : 2014-10-16 Núcleo de Informação e Coordenação do Ponto BR - NIC.br
 bom
 
-// bond : 2014-06-05 Bond University Limited
+// bond : 2014-06-05 ShortDot SA
 bond
 
 // boo : 2014-01-30 Charleston Road Registry Inc.
 boo
 
-// book : 2015-08-27 Amazon EU S.à r.l.
+// book : 2015-08-27 Amazon Registry Services, Inc.
 book
 
 // booking : 2015-07-16 Booking.com B.V.
 booking
-
-// boots : 2015-01-08 THE BOOTS COMPANY PLC
-boots
 
 // bosch : 2015-06-18 Robert Bosch GMBH
 bosch
@@ -7219,16 +7525,16 @@ bosch
 // bostik : 2015-05-28 Bostik SA
 bostik
 
-// boston : 2015-12-10
+// boston : 2015-12-10 Registry Services, LLC
 boston
 
-// bot : 2014-12-18 Amazon EU S.à r.l.
+// bot : 2014-12-18 Amazon Registry Services, Inc.
 bot
 
-// boutique : 2013-11-14 Over Galley, LLC
+// boutique : 2013-11-14 Binky Moon, LLC
 boutique
 
-// box : 2015-11-12 NS1 Limited
+// box : 2015-11-12 Intercap Registry Inc.
 box
 
 // bradesco : 2014-12-18 Banco Bradesco S.A.
@@ -7240,7 +7546,7 @@ bridgestone
 // broadway : 2014-12-22 Celebrate Broadway, Inc.
 broadway
 
-// broker : 2014-12-11 IG Group Holdings PLC
+// broker : 2014-12-11 Dog Beach, LLC
 broker
 
 // brother : 2015-01-29 Brother Industries, Ltd.
@@ -7249,22 +7555,19 @@ brother
 // brussels : 2014-02-06 DNS.be vzw
 brussels
 
-// budapest : 2013-11-21 Top Level Domain Holdings Limited
-budapest
-
 // bugatti : 2015-07-23 Bugatti International SA
 bugatti
 
 // build : 2013-11-07 Plan Bee LLC
 build
 
-// builders : 2013-11-07 Atomic Madison, LLC
+// builders : 2013-11-07 Binky Moon, LLC
 builders
 
-// business : 2013-11-07 Spring Cross, LLC
+// business : 2013-11-07 Binky Moon, LLC
 business
 
-// buy : 2014-12-18 Amazon EU S.à r.l.
+// buy : 2014-12-18 Amazon Registry Services, Inc.
 buy
 
 // buzz : 2013-10-02 DOTSTRATEGY CO.
@@ -7273,28 +7576,28 @@ buzz
 // bzh : 2014-02-27 Association www.bzh
 bzh
 
-// cab : 2013-10-24 Half Sunset, LLC
+// cab : 2013-10-24 Binky Moon, LLC
 cab
 
-// cafe : 2015-02-11 Pioneer Canyon, LLC
+// cafe : 2015-02-11 Binky Moon, LLC
 cafe
 
 // cal : 2014-07-24 Charleston Road Registry Inc.
 cal
 
-// call : 2014-12-18 Amazon EU S.à r.l.
+// call : 2014-12-18 Amazon Registry Services, Inc.
 call
 
 // calvinklein : 2015-07-30 PVH gTLD Holdings LLC
 calvinklein
 
-// cam : 2016-04-21 AC Webconnecting Holding B.V.
+// cam : 2016-04-21 Cam Connecting SARL
 cam
 
-// camera : 2013-08-27 Atomic Maple, LLC
+// camera : 2013-08-27 Binky Moon, LLC
 camera
 
-// camp : 2013-11-07 Delta Dynamite, LLC
+// camp : 2013-11-07 Binky Moon, LLC
 camp
 
 // cancerresearch : 2014-05-15 Australian Cancer Research Foundation
@@ -7306,52 +7609,46 @@ canon
 // capetown : 2014-03-24 ZA Central Registry NPC trading as ZA Central Registry
 capetown
 
-// capital : 2014-03-06 Delta Mill, LLC
+// capital : 2014-03-06 Binky Moon, LLC
 capital
 
 // capitalone : 2015-08-06 Capital One Financial Corporation
 capitalone
 
-// car : 2015-01-22
+// car : 2015-01-22 XYZ.COM LLC
 car
 
 // caravan : 2013-12-12 Caravan International, Inc.
 caravan
 
-// cards : 2013-12-05 Foggy Hollow, LLC
+// cards : 2013-12-05 Binky Moon, LLC
 cards
 
-// care : 2014-03-06 Goose Cross
+// care : 2014-03-06 Binky Moon, LLC
 care
 
 // career : 2013-10-09 dotCareer LLC
 career
 
-// careers : 2013-10-02 Wild Corner, LLC
+// careers : 2013-10-02 Binky Moon, LLC
 careers
 
-// cars : 2014-11-13
+// cars : 2014-11-13 XYZ.COM LLC
 cars
 
-// cartier : 2014-06-23 Richemont DNS Inc.
-cartier
-
-// casa : 2013-11-21 Top Level Domain Holdings Limited
+// casa : 2013-11-21 Registry Services, LLC
 casa
 
-// case : 2015-09-03 CNH Industrial N.V.
+// case : 2015-09-03 Helium TLDs Ltd
 case
 
-// caseih : 2015-09-03 CNH Industrial N.V.
-caseih
-
-// cash : 2014-03-06 Delta Lake, LLC
+// cash : 2014-03-06 Binky Moon, LLC
 cash
 
-// casino : 2014-12-18 Binky Sky, LLC
+// casino : 2014-12-18 Binky Moon, LLC
 casino
 
-// catering : 2013-12-05 New Falls. LLC
+// catering : 2013-12-05 Binky Moon, LLC
 catering
 
 // catholic : 2015-10-21 Pontificium Consilium de Comunicationibus Socialibus (PCCS) (Pontifical Council for Social Communication)
@@ -7369,10 +7666,7 @@ cbre
 // cbs : 2015-08-06 CBS Domains Inc.
 cbs
 
-// ceb : 2015-04-09 The Corporate Executive Board Company
-ceb
-
-// center : 2013-11-07 Tin Mill, LLC
+// center : 2013-11-07 Binky Moon, LLC
 center
 
 // ceo : 2013-11-07 CEOTLD Pty Ltd
@@ -7384,7 +7678,7 @@ cern
 // cfa : 2014-08-28 CFA Institute
 cfa
 
-// cfd : 2014-12-11 IG Group Holdings PLC
+// cfd : 2014-12-11 ShortDot SA
 cfd
 
 // chanel : 2015-04-09 Chanel International B.V.
@@ -7393,37 +7687,34 @@ chanel
 // channel : 2014-05-08 Charleston Road Registry Inc.
 channel
 
-// chase : 2015-04-30 JPMorgan Chase & Co.
+// charity : 2018-04-11 Binky Moon, LLC
+charity
+
+// chase : 2015-04-30 JPMorgan Chase Bank, National Association
 chase
 
-// chat : 2014-12-04 Sand Fields, LLC
+// chat : 2014-12-04 Binky Moon, LLC
 chat
 
-// cheap : 2013-11-14 Sand Cover, LLC
+// cheap : 2013-11-14 Binky Moon, LLC
 cheap
 
 // chintai : 2015-06-11 CHINTAI Corporation
 chintai
 
-// chloe : 2014-10-16 Richemont DNS Inc.
-chloe
-
-// christmas : 2013-11-21 Uniregistry, Corp.
+// christmas : 2013-11-21 XYZ.COM LLC
 christmas
 
 // chrome : 2014-07-24 Charleston Road Registry Inc.
 chrome
 
-// chrysler : 2015-07-30 FCA US LLC.
-chrysler
-
-// church : 2014-02-06 Holly Fields, LLC
+// church : 2014-02-06 Binky Moon, LLC
 church
 
 // cipriani : 2015-02-19 Hotel Cipriani Srl
 cipriani
 
-// circle : 2014-12-18 Amazon EU S.à r.l.
+// circle : 2014-12-18 Amazon Registry Services, Inc.
 circle
 
 // cisco : 2014-12-22 Cisco Technology, Inc.
@@ -7438,52 +7729,52 @@ citi
 // citic : 2014-01-09 CITIC Group Corporation
 citic
 
-// city : 2014-05-29 Snow Sky, LLC
+// city : 2014-05-29 Binky Moon, LLC
 city
 
 // cityeats : 2014-12-11 Lifestyle Domain Holdings, Inc.
 cityeats
 
-// claims : 2014-03-20 Black Corner, LLC
+// claims : 2014-03-20 Binky Moon, LLC
 claims
 
-// cleaning : 2013-12-05 Fox Shadow, LLC
+// cleaning : 2013-12-05 Binky Moon, LLC
 cleaning
 
-// click : 2014-06-05 Uniregistry, Corp.
+// click : 2014-06-05 UNR Corp.
 click
 
-// clinic : 2014-03-20 Goose Park, LLC
+// clinic : 2014-03-20 Binky Moon, LLC
 clinic
 
 // clinique : 2015-10-01 The Estée Lauder Companies Inc.
 clinique
 
-// clothing : 2013-08-27 Steel Lake, LLC
+// clothing : 2013-08-27 Binky Moon, LLC
 clothing
 
-// cloud : 2015-04-16 ARUBA S.p.A.
+// cloud : 2015-04-16 Aruba PEC S.p.A.
 cloud
 
-// club : 2013-11-08 .CLUB DOMAINS, LLC
+// club : 2013-11-08 Registry Services, LLC
 club
 
 // clubmed : 2015-06-25 Club Méditerranée S.A.
 clubmed
 
-// coach : 2014-10-09 Koko Island, LLC
+// coach : 2014-10-09 Binky Moon, LLC
 coach
 
-// codes : 2013-10-31 Puff Willow, LLC
+// codes : 2013-10-31 Binky Moon, LLC
 codes
 
-// coffee : 2013-10-17 Trixy Cover, LLC
+// coffee : 2013-10-17 Binky Moon, LLC
 coffee
 
 // college : 2014-01-16 XYZ.COM LLC
 college
 
-// cologne : 2014-02-05 NetCologne Gesellschaft für Telekommunikation mbH
+// cologne : 2014-02-05 dotKoeln GmbH
 cologne
 
 // comcast : 2015-07-23 Comcast IP Holdings I, LLC
@@ -7492,67 +7783,70 @@ comcast
 // commbank : 2014-06-26 COMMONWEALTH BANK OF AUSTRALIA
 commbank
 
-// community : 2013-12-05 Fox Orchard, LLC
+// community : 2013-12-05 Binky Moon, LLC
 community
 
-// company : 2013-11-07 Silver Avenue, LLC
+// company : 2013-11-07 Binky Moon, LLC
 company
 
-// compare : 2015-10-08 iSelect Ltd
+// compare : 2015-10-08 Registry Services, LLC
 compare
 
-// computer : 2013-10-24 Pine Mill, LLC
+// computer : 2013-10-24 Binky Moon, LLC
 computer
 
 // comsec : 2015-01-08 VeriSign, Inc.
 comsec
 
-// condos : 2013-12-05 Pine House, LLC
+// condos : 2013-12-05 Binky Moon, LLC
 condos
 
-// construction : 2013-09-16 Fox Dynamite, LLC
+// construction : 2013-09-16 Binky Moon, LLC
 construction
 
-// consulting : 2013-12-05
+// consulting : 2013-12-05 Dog Beach, LLC
 consulting
 
-// contact : 2015-01-08 Top Level Spectrum, Inc.
+// contact : 2015-01-08 Dog Beach, LLC
 contact
 
-// contractors : 2013-09-10 Magic Woods, LLC
+// contractors : 2013-09-10 Binky Moon, LLC
 contractors
 
-// cooking : 2013-11-21 Top Level Domain Holdings Limited
+// cooking : 2013-11-21 Registry Services, LLC
 cooking
 
 // cookingchannel : 2015-07-02 Lifestyle Domain Holdings, Inc.
 cookingchannel
 
-// cool : 2013-11-14 Koko Lake, LLC
+// cool : 2013-11-14 Binky Moon, LLC
 cool
 
-// corsica : 2014-09-25 Collectivité Territoriale de Corse
+// corsica : 2014-09-25 Collectivité de Corse
 corsica
 
-// country : 2013-12-19 Top Level Domain Holdings Limited
+// country : 2013-12-19 DotCountry LLC
 country
 
-// coupon : 2015-02-26 Amazon EU S.à r.l.
+// coupon : 2015-02-26 Amazon Registry Services, Inc.
 coupon
 
-// coupons : 2015-03-26 Black Island, LLC
+// coupons : 2015-03-26 Binky Moon, LLC
 coupons
 
 // courses : 2014-12-04 OPEN UNIVERSITIES AUSTRALIA PTY LTD
 courses
 
-// credit : 2014-03-20 Snow Shadow, LLC
+// cpa : 2019-06-10 American Institute of Certified Public Accountants
+cpa
+
+// credit : 2014-03-20 Binky Moon, LLC
 credit
 
-// creditcard : 2014-03-20 Binky Frostbite, LLC
+// creditcard : 2014-03-20 Binky Moon, LLC
 creditcard
 
-// creditunion : 2015-01-22 CUNA Performance Resources, LLC
+// creditunion : 2015-01-22 DotCooperation LLC
 creditunion
 
 // cricket : 2014-10-09 dot Cricket Limited
@@ -7567,19 +7861,16 @@ crs
 // cruise : 2015-12-10 Viking River Cruises (Bermuda) Ltd.
 cruise
 
-// cruises : 2013-12-05 Spring Way, LLC
+// cruises : 2013-12-05 Binky Moon, LLC
 cruises
 
-// csc : 2014-09-25 Alliance-One Services, Inc.
-csc
-
-// cuisinella : 2014-04-03 SALM S.A.S.
+// cuisinella : 2014-04-03 SCHMIDT GROUPE S.A.S.
 cuisinella
 
 // cymru : 2014-05-08 Nominet UK
 cymru
 
-// cyou : 2015-01-22 Beijing Gamease Age Digital Technology Co., Ltd.
+// cyou : 2015-01-22 ShortDot SA
 cyou
 
 // dabur : 2014-02-06 Dabur India Limited
@@ -7588,7 +7879,7 @@ dabur
 // dad : 2014-01-23 Charleston Road Registry Inc.
 dad
 
-// dance : 2013-10-24 United TLD Holdco Ltd.
+// dance : 2013-10-24 Dog Beach, LLC
 dance
 
 // data : 2016-06-02 Dish DBS Corporation
@@ -7597,7 +7888,7 @@ data
 // date : 2014-11-20 dot Date Limited
 date
 
-// dating : 2013-12-05 Pine Fest, LLC
+// dating : 2013-12-05 Binky Moon, LLC
 dating
 
 // datsun : 2014-03-27 NISSAN MOTOR CO., LTD.
@@ -7609,22 +7900,22 @@ day
 // dclk : 2014-11-20 Charleston Road Registry Inc.
 dclk
 
-// dds : 2015-05-07 Top Level Domain Holdings Limited
+// dds : 2015-05-07 Registry Services, LLC
 dds
 
-// deal : 2015-06-25 Amazon EU S.à r.l.
+// deal : 2015-06-25 Amazon Registry Services, Inc.
 deal
 
-// dealer : 2014-12-22 Dealer Dot Com, Inc.
+// dealer : 2014-12-22 Intercap Registry Inc.
 dealer
 
-// deals : 2014-05-22 Sand Sunset, LLC
+// deals : 2014-05-22 Binky Moon, LLC
 deals
 
-// degree : 2014-03-06
+// degree : 2014-03-06 Dog Beach, LLC
 degree
 
-// delivery : 2014-09-11 Steel Station, LLC
+// delivery : 2014-09-11 Binky Moon, LLC
 delivery
 
 // dell : 2014-10-24 Dell Inc.
@@ -7636,19 +7927,19 @@ deloitte
 // delta : 2015-02-19 Delta Air Lines, Inc.
 delta
 
-// democrat : 2013-10-24 United TLD Holdco Ltd.
+// democrat : 2013-10-24 Dog Beach, LLC
 democrat
 
-// dental : 2014-03-20 Tin Birch, LLC
+// dental : 2014-03-20 Binky Moon, LLC
 dental
 
-// dentist : 2014-03-20
+// dentist : 2014-03-20 Dog Beach, LLC
 dentist
 
 // desi : 2013-11-14 Desi Networks LLC
 desi
 
-// design : 2014-11-07 Top Level Design, LLC
+// design : 2014-11-07 Registry Services, LLC
 design
 
 // dev : 2014-10-16 Charleston Road Registry Inc.
@@ -7657,22 +7948,22 @@ dev
 // dhl : 2015-07-23 Deutsche Post AG
 dhl
 
-// diamonds : 2013-09-22 John Edge, LLC
+// diamonds : 2013-09-22 Binky Moon, LLC
 diamonds
 
-// diet : 2014-06-26 Uniregistry, Corp.
+// diet : 2014-06-26 XYZ.COM LLC
 diet
 
-// digital : 2014-03-06 Dash Park, LLC
+// digital : 2014-03-06 Binky Moon, LLC
 digital
 
-// direct : 2014-04-10 Half Trail, LLC
+// direct : 2014-04-10 Binky Moon, LLC
 direct
 
-// directory : 2013-09-20 Extra Madison, LLC
+// directory : 2013-09-20 Binky Moon, LLC
 directory
 
-// discount : 2014-03-06 Holly Hill, LLC
+// discount : 2014-03-06 Binky Moon, LLC
 discount
 
 // discover : 2015-07-23 Discover Financial Services
@@ -7690,19 +7981,13 @@ dnp
 // docs : 2014-10-16 Charleston Road Registry Inc.
 docs
 
-// doctor : 2016-06-02 Brice Trail, LLC
+// doctor : 2016-06-02 Binky Moon, LLC
 doctor
 
-// dodge : 2015-07-30 FCA US LLC.
-dodge
-
-// dog : 2014-12-04 Koko Mill, LLC
+// dog : 2014-12-04 Binky Moon, LLC
 dog
 
-// doha : 2014-09-18 Communications Regulatory Authority (CRA)
-doha
-
-// domains : 2013-10-17 Sugar Cross, LLC
+// domains : 2013-10-17 Binky Moon, LLC
 domains
 
 // dot : 2015-05-21 Dish DBS Corporation
@@ -7720,16 +8005,10 @@ dtv
 // dubai : 2015-01-01 Dubai Smart Government Department
 dubai
 
-// duck : 2015-07-23 Johnson Shareholdings, Inc.
-duck
-
 // dunlop : 2015-07-02 The Goodyear Tire & Rubber Company
 dunlop
 
-// duns : 2015-08-06 The Dun & Bradstreet Corporation
-duns
-
-// dupont : 2015-06-25 E. I. du Pont de Nemours and Company
+// dupont : 2015-06-25 DuPont Specialty Products USA, LLC
 dupont
 
 // durban : 2014-03-24 ZA Central Registry NPC trading as ZA Central Registry
@@ -7738,7 +8017,7 @@ durban
 // dvag : 2014-06-23 Deutsche Vermögensberatung Aktiengesellschaft DVAG
 dvag
 
-// dvr : 2016-05-26 Hughes Satellite Systems Corporation
+// dvr : 2016-05-26 DISH Technologies L.L.C.
 dvr
 
 // earth : 2014-12-04 Interlink Co., Ltd.
@@ -7753,34 +8032,31 @@ eco
 // edeka : 2014-12-18 EDEKA Verband kaufmännischer Genossenschaften e.V.
 edeka
 
-// education : 2013-11-07 Brice Way, LLC
+// education : 2013-11-07 Binky Moon, LLC
 education
 
-// email : 2013-10-31 Spring Madison, LLC
+// email : 2013-10-31 Binky Moon, LLC
 email
 
 // emerck : 2014-04-03 Merck KGaA
 emerck
 
-// energy : 2014-09-11 Binky Birch, LLC
+// energy : 2014-09-11 Binky Moon, LLC
 energy
 
-// engineer : 2014-03-06 United TLD Holdco Ltd.
+// engineer : 2014-03-06 Dog Beach, LLC
 engineer
 
-// engineering : 2014-03-06 Romeo Canyon
+// engineering : 2014-03-06 Binky Moon, LLC
 engineering
 
-// enterprises : 2013-09-20 Snow Oaks, LLC
+// enterprises : 2013-09-20 Binky Moon, LLC
 enterprises
-
-// epost : 2015-07-23 Deutsche Post AG
-epost
 
 // epson : 2014-12-04 Seiko Epson Corporation
 epson
 
-// equipment : 2013-08-27 Corn Station, LLC
+// equipment : 2013-08-27 Binky Moon, LLC
 equipment
 
 // ericsson : 2015-07-09 Telefonaktiebolaget L M Ericsson
@@ -7792,11 +8068,8 @@ erni
 // esq : 2014-05-08 Charleston Road Registry Inc.
 esq
 
-// estate : 2013-08-27 Trixy Park, LLC
+// estate : 2013-08-27 Binky Moon, LLC
 estate
-
-// esurance : 2015-07-23 Esurance Insurance Company
-esurance
 
 // etisalat : 2015-09-03 Emirates Telecommunications Corporation (trading as Etisalat)
 etisalat
@@ -7807,22 +8080,19 @@ eurovision
 // eus : 2013-12-12 Puntueus Fundazioa
 eus
 
-// events : 2013-12-05 Pioneer Maple, LLC
+// events : 2013-12-05 Binky Moon, LLC
 events
 
-// everbank : 2014-05-15 EverBank
-everbank
-
-// exchange : 2014-03-06 Spring Falls, LLC
+// exchange : 2014-03-06 Binky Moon, LLC
 exchange
 
-// expert : 2013-11-21 Magic Pass, LLC
+// expert : 2013-11-21 Binky Moon, LLC
 expert
 
-// exposed : 2013-12-05 Victor Beach, LLC
+// exposed : 2013-12-05 Binky Moon, LLC
 exposed
 
-// express : 2015-02-11 Sea Sunset, LLC
+// express : 2015-02-11 Binky Moon, LLC
 express
 
 // extraspace : 2015-05-14 Extra Space Storage LLC
@@ -7831,7 +8101,7 @@ extraspace
 // fage : 2014-12-18 Fage International S.A.
 fage
 
-// fail : 2014-03-06 Atomic Pipe, LLC
+// fail : 2014-03-06 Binky Moon, LLC
 fail
 
 // fairwinds : 2014-11-13 FairWinds Partners, LLC
@@ -7840,25 +8110,25 @@ fairwinds
 // faith : 2014-11-20 dot Faith Limited
 faith
 
-// family : 2015-04-02
+// family : 2015-04-02 Dog Beach, LLC
 family
 
-// fan : 2014-03-06
+// fan : 2014-03-06 Dog Beach, LLC
 fan
 
-// fans : 2014-11-07 Asiamix Digital Limited
+// fans : 2014-11-07 ZDNS International Limited
 fans
 
-// farm : 2013-11-07 Just Maple, LLC
+// farm : 2013-11-07 Binky Moon, LLC
 farm
 
 // farmers : 2015-07-09 Farmers Insurance Exchange
 farmers
 
-// fashion : 2014-07-03 Top Level Domain Holdings Limited
+// fashion : 2014-07-03 Registry Services, LLC
 fashion
 
-// fast : 2014-12-18 Amazon EU S.à r.l.
+// fast : 2014-12-18 Amazon Registry Services, Inc.
 fast
 
 // fedex : 2015-08-06 Federal Express Corporation
@@ -7879,7 +8149,7 @@ fiat
 // fidelity : 2015-07-30 Fidelity Brokerage Services LLC
 fidelity
 
-// fido : 2015-08-06 Rogers Communications Partnership
+// fido : 2015-08-06 Rogers Communications Canada Inc.
 fido
 
 // film : 2015-01-08 Motion Picture Domain Registry Pty Ltd
@@ -7888,46 +8158,46 @@ film
 // final : 2014-10-16 Núcleo de Informação e Coordenação do Ponto BR - NIC.br
 final
 
-// finance : 2014-03-20 Cotton Cypress, LLC
+// finance : 2014-03-20 Binky Moon, LLC
 finance
 
-// financial : 2014-03-06 Just Cover, LLC
+// financial : 2014-03-06 Binky Moon, LLC
 financial
 
-// fire : 2015-06-25 Amazon EU S.à r.l.
+// fire : 2015-06-25 Amazon Registry Services, Inc.
 fire
 
-// firestone : 2014-12-18 Bridgestone Corporation
+// firestone : 2014-12-18 Bridgestone Licensing Services, Inc
 firestone
 
 // firmdale : 2014-03-27 Firmdale Holdings Limited
 firmdale
 
-// fish : 2013-12-12 Fox Woods, LLC
+// fish : 2013-12-12 Binky Moon, LLC
 fish
 
-// fishing : 2013-11-21 Top Level Domain Holdings Limited
+// fishing : 2013-11-21 Registry Services, LLC
 fishing
 
-// fit : 2014-11-07 Top Level Domain Holdings Limited
+// fit : 2014-11-07 Registry Services, LLC
 fit
 
-// fitness : 2014-03-06 Brice Orchard, LLC
+// fitness : 2014-03-06 Binky Moon, LLC
 fitness
 
-// flickr : 2015-04-02 Yahoo! Domain Services Inc.
+// flickr : 2015-04-02 Flickr, Inc.
 flickr
 
-// flights : 2013-12-05 Fox Station, LLC
+// flights : 2013-12-05 Binky Moon, LLC
 flights
 
 // flir : 2015-07-23 FLIR Systems, Inc.
 flir
 
-// florist : 2013-11-07 Half Cypress, LLC
+// florist : 2013-11-07 Binky Moon, LLC
 florist
 
-// flowers : 2014-10-09 Uniregistry, Corp.
+// flowers : 2014-10-09 XYZ.COM LLC
 flowers
 
 // fly : 2014-05-08 Charleston Road Registry Inc.
@@ -7942,28 +8212,28 @@ food
 // foodnetwork : 2015-07-02 Lifestyle Domain Holdings, Inc.
 foodnetwork
 
-// football : 2014-12-18 Foggy Farms, LLC
+// football : 2014-12-18 Binky Moon, LLC
 football
 
 // ford : 2014-11-13 Ford Motor Company
 ford
 
-// forex : 2014-12-11 IG Group Holdings PLC
+// forex : 2014-12-11 Dog Beach, LLC
 forex
 
-// forsale : 2014-05-22
+// forsale : 2014-05-22 Dog Beach, LLC
 forsale
 
 // forum : 2015-04-02 Fegistry, LLC
 forum
 
-// foundation : 2013-12-05 John Dale, LLC
+// foundation : 2013-12-05 Binky Moon, LLC
 foundation
 
 // fox : 2015-09-11 FOX Registry, LLC
 fox
 
-// free : 2015-12-10 Amazon EU S.à r.l.
+// free : 2015-12-10 Amazon Registry Services, Inc.
 free
 
 // fresenius : 2015-07-30 Fresenius Immobilien-Verwaltungs-GmbH
@@ -7987,28 +8257,25 @@ ftr
 // fujitsu : 2015-07-30 Fujitsu Limited
 fujitsu
 
-// fujixerox : 2015-07-23 Xerox DNHC LLC
-fujixerox
-
-// fun : 2016-01-14
+// fun : 2016-01-14 Radix FZC
 fun
 
-// fund : 2014-03-20 John Castle, LLC
+// fund : 2014-03-20 Binky Moon, LLC
 fund
 
-// furniture : 2014-03-20 Lone Fields, LLC
+// furniture : 2014-03-20 Binky Moon, LLC
 furniture
 
-// futbol : 2013-09-20
+// futbol : 2013-09-20 Dog Beach, LLC
 futbol
 
-// fyi : 2015-04-02 Silver Tigers, LLC
+// fyi : 2015-04-02 Binky Moon, LLC
 fyi
 
 // gal : 2013-11-07 Asociación puntoGAL
 gal
 
-// gallery : 2013-09-13 Sugar House, LLC
+// gallery : 2013-09-13 Binky Moon, LLC
 gallery
 
 // gallo : 2015-06-11 Gallo Vineyards, Inc.
@@ -8017,17 +8284,20 @@ gallo
 // gallup : 2015-02-19 Gallup, Inc.
 gallup
 
-// game : 2015-05-28 Uniregistry, Corp.
+// game : 2015-05-28 XYZ.COM LLC
 game
 
-// games : 2015-05-28
+// games : 2015-05-28 Dog Beach, LLC
 games
 
 // gap : 2015-07-31 The Gap, Inc.
 gap
 
-// garden : 2014-06-26 Top Level Domain Holdings Limited
+// garden : 2014-06-26 Registry Services, LLC
 garden
+
+// gay : 2019-05-23 Top Level Design, LLC
+gay
 
 // gbiz : 2014-07-17 Charleston Road Registry Inc.
 gbiz
@@ -8038,7 +8308,7 @@ gdn
 // gea : 2014-12-04 GEA Group Aktiengesellschaft
 gea
 
-// gent : 2014-01-23 COMBELL GROUP NV/SA
+// gent : 2014-01-23 Easyhost BV
 gent
 
 // genting : 2015-03-12 Resorts World Inc Pte. Ltd.
@@ -8050,28 +8320,25 @@ george
 // ggee : 2014-01-09 GMO Internet, Inc.
 ggee
 
-// gift : 2013-10-17 Uniregistry, Corp.
+// gift : 2013-10-17 DotGift, LLC
 gift
 
-// gifts : 2014-07-03 Goose Sky, LLC
+// gifts : 2014-07-03 Binky Moon, LLC
 gifts
 
-// gives : 2014-03-06 United TLD Holdco Ltd.
+// gives : 2014-03-06 Dog Beach, LLC
 gives
 
 // giving : 2014-11-13 Giving Limited
 giving
 
-// glade : 2015-07-23 Johnson Shareholdings, Inc.
-glade
-
-// glass : 2013-11-07 Black Cover, LLC
+// glass : 2013-11-07 Binky Moon, LLC
 glass
 
 // gle : 2014-07-24 Charleston Road Registry Inc.
 gle
 
-// global : 2014-04-17 Dot GLOBAL AS
+// global : 2014-04-17 Dot Global Domain Registry Limited
 global
 
 // globo : 2013-12-19 Globo Comunicação e Participações S.A
@@ -8080,7 +8347,7 @@ globo
 // gmail : 2014-05-01 Charleston Road Registry Inc.
 gmail
 
-// gmbh : 2016-01-29 Extra Dynamite, LLC
+// gmbh : 2016-01-29 Binky Moon, LLC
 gmbh
 
 // gmo : 2014-01-09 GMO Internet, Inc.
@@ -8092,20 +8359,17 @@ gmx
 // godaddy : 2015-07-23 Go Daddy East, LLC
 godaddy
 
-// gold : 2015-01-22 June Edge, LLC
+// gold : 2015-01-22 Binky Moon, LLC
 gold
 
 // goldpoint : 2014-11-20 YODOBASHI CAMERA CO.,LTD.
 goldpoint
 
-// golf : 2014-12-18 Lone falls, LLC
+// golf : 2014-12-18 Binky Moon, LLC
 golf
 
 // goo : 2014-12-18 NTT Resonant Inc.
 goo
-
-// goodhands : 2015-07-31 Allstate Fire and Casualty Insurance Company
-goodhands
 
 // goodyear : 2015-07-02 The Goodyear Tire & Rubber Company
 goodyear
@@ -8119,28 +8383,28 @@ google
 // gop : 2014-01-16 Republican State Leadership Committee, Inc.
 gop
 
-// got : 2014-12-18 Amazon EU S.à r.l.
+// got : 2014-12-18 Amazon Registry Services, Inc.
 got
 
 // grainger : 2015-05-07 Grainger Registry Services, LLC
 grainger
 
-// graphics : 2013-09-13 Over Madison, LLC
+// graphics : 2013-09-13 Binky Moon, LLC
 graphics
 
-// gratis : 2014-03-20 Pioneer Tigers, LLC
+// gratis : 2014-03-20 Binky Moon, LLC
 gratis
 
 // green : 2014-05-08 Afilias Limited
 green
 
-// gripe : 2014-03-06 Corn Sunset, LLC
+// gripe : 2014-03-06 Binky Moon, LLC
 gripe
 
 // grocery : 2016-06-16 Wal-Mart Stores, Inc.
 grocery
 
-// group : 2014-08-15 Romeo Town, LLC
+// group : 2014-08-15 Binky Moon, LLC
 group
 
 // guardian : 2015-07-30 The Guardian Life Insurance Company of America
@@ -8152,16 +8416,16 @@ gucci
 // guge : 2014-08-28 Charleston Road Registry Inc.
 guge
 
-// guide : 2013-09-13 Snow Moon, LLC
+// guide : 2013-09-13 Binky Moon, LLC
 guide
 
-// guitars : 2013-11-14 Uniregistry, Corp.
+// guitars : 2013-11-14 XYZ.COM LLC
 guitars
 
-// guru : 2013-08-27 Pioneer Cypress, LLC
+// guru : 2013-08-27 Binky Moon, LLC
 guru
 
-// hair : 2015-12-03 L'Oréal
+// hair : 2015-12-03 XYZ.COM LLC
 hair
 
 // hamburg : 2014-02-20 Hamburg Top-Level-Domain GmbH
@@ -8170,7 +8434,7 @@ hamburg
 // hangout : 2014-11-13 Charleston Road Registry Inc.
 hangout
 
-// haus : 2013-12-05
+// haus : 2013-12-05 Dog Beach, LLC
 haus
 
 // hbo : 2015-07-30 HBO Registry Services, Inc.
@@ -8185,10 +8449,10 @@ hdfcbank
 // health : 2015-02-11 DotHealth, LLC
 health
 
-// healthcare : 2014-06-12 Silver Glen, LLC
+// healthcare : 2014-06-12 Binky Moon, LLC
 healthcare
 
-// help : 2014-06-26 Uniregistry, Corp.
+// help : 2014-06-26 UNR Corp.
 help
 
 // helsinki : 2015-02-05 City of Helsinki
@@ -8203,7 +8467,7 @@ hermes
 // hgtv : 2015-07-02 Lifestyle Domain Holdings, Inc.
 hgtv
 
-// hiphop : 2014-03-06 Uniregistry, Corp.
+// hiphop : 2014-03-06 Dot Hip Hop, LLC
 hiphop
 
 // hisamitsu : 2015-07-16 Hisamitsu Pharmaceutical Co.,Inc.
@@ -8212,28 +8476,28 @@ hisamitsu
 // hitachi : 2014-10-31 Hitachi, Ltd.
 hitachi
 
-// hiv : 2014-03-13
+// hiv : 2014-03-13 UNR Corp.
 hiv
 
 // hkt : 2015-05-14 PCCW-HKT DataCom Services Limited
 hkt
 
-// hockey : 2015-03-19 Half Willow, LLC
+// hockey : 2015-03-19 Binky Moon, LLC
 hockey
 
-// holdings : 2013-08-27 John Madison, LLC
+// holdings : 2013-08-27 Binky Moon, LLC
 holdings
 
-// holiday : 2013-11-07 Goose Woods, LLC
+// holiday : 2013-11-07 Binky Moon, LLC
 holiday
 
-// homedepot : 2015-04-02 Homer TLC, Inc.
+// homedepot : 2015-04-02 Home Depot Product Authority, LLC
 homedepot
 
 // homegoods : 2015-07-16 The TJX Companies, Inc.
 homegoods
 
-// homes : 2014-01-09 DERHomes, LLC
+// homes : 2014-01-09 XYZ.COM LLC
 homes
 
 // homesense : 2015-07-16 The TJX Companies, Inc.
@@ -8242,22 +8506,19 @@ homesense
 // honda : 2014-12-18 Honda Motor Co., Ltd.
 honda
 
-// honeywell : 2015-07-23 Honeywell GTLD LLC
-honeywell
-
-// horse : 2013-11-21 Top Level Domain Holdings Limited
+// horse : 2013-11-21 Registry Services, LLC
 horse
 
-// hospital : 2016-10-20 Ruby Pike, LLC
+// hospital : 2016-10-20 Binky Moon, LLC
 hospital
 
-// host : 2014-04-17 DotHost Inc.
+// host : 2014-04-17 Radix FZC
 host
 
-// hosting : 2014-05-29 Uniregistry, Corp.
+// hosting : 2014-05-29 XYZ.COM LLC
 hosting
 
-// hot : 2015-08-27 Amazon EU S.à r.l.
+// hot : 2015-08-27 Amazon Registry Services, Inc.
 hot
 
 // hoteles : 2015-03-05 Travel Reservations SRL
@@ -8269,17 +8530,14 @@ hotels
 // hotmail : 2014-12-18 Microsoft Corporation
 hotmail
 
-// house : 2013-11-07 Sugar Park, LLC
+// house : 2013-11-07 Binky Moon, LLC
 house
 
 // how : 2014-01-23 Charleston Road Registry Inc.
 how
 
-// hsbc : 2014-10-24 HSBC Holdings PLC
+// hsbc : 2014-10-24 HSBC Global Services (UK) Limited
 hsbc
-
-// htc : 2015-04-02 HTC corporation
-htc
 
 // hughes : 2015-07-30 Hughes Satellite Systems Corporation
 hughes
@@ -8299,7 +8557,7 @@ icbc
 // ice : 2014-10-30 IntercontinentalExchange, Inc.
 ice
 
-// icu : 2015-01-08 One.com A/S
+// icu : 2015-01-08 ShortDot SA
 icu
 
 // ieee : 2015-07-23 IEEE Global LLC
@@ -8314,16 +8572,19 @@ ikano
 // imamat : 2015-08-06 Fondation Aga Khan (Aga Khan Foundation)
 imamat
 
-// imdb : 2015-06-25 Amazon EU S.à r.l.
+// imdb : 2015-06-25 Amazon Registry Services, Inc.
 imdb
 
-// immo : 2014-07-10 Auburn Bloom, LLC
+// immo : 2014-07-10 Binky Moon, LLC
 immo
 
-// immobilien : 2013-11-07 United TLD Holdco Ltd.
+// immobilien : 2013-11-07 Dog Beach, LLC
 immobilien
 
-// industries : 2013-12-05 Outer House, LLC
+// inc : 2018-03-10 Intercap Registry Inc.
+inc
+
+// industries : 2013-12-05 Binky Moon, LLC
 industries
 
 // infiniti : 2014-03-27 NISSAN MOTOR CO., LTD.
@@ -8335,35 +8596,29 @@ ing
 // ink : 2013-12-05 Top Level Design, LLC
 ink
 
-// institute : 2013-11-07 Outer Maple, LLC
+// institute : 2013-11-07 Binky Moon, LLC
 institute
 
 // insurance : 2015-02-19 fTLD Registry Services LLC
 insurance
 
-// insure : 2014-03-20 Pioneer Willow, LLC
+// insure : 2014-03-20 Binky Moon, LLC
 insure
 
-// intel : 2015-08-06 Intel Corporation
-intel
-
-// international : 2013-11-07 Wild Way, LLC
+// international : 2013-11-07 Binky Moon, LLC
 international
 
 // intuit : 2015-07-30 Intuit Administrative Services, Inc.
 intuit
 
-// investments : 2014-03-20 Holly Glen, LLC
+// investments : 2014-03-20 Binky Moon, LLC
 investments
 
 // ipiranga : 2014-08-28 Ipiranga Produtos de Petroleo S.A.
 ipiranga
 
-// irish : 2014-08-07 Dot-Irish LLC
+// irish : 2014-08-07 Binky Moon, LLC
 irish
-
-// iselect : 2015-02-11 iSelect Ltd
-iselect
 
 // ismaili : 2015-08-06 Fondation Aga Khan (Aga Khan Foundation)
 ismaili
@@ -8380,12 +8635,6 @@ itau
 // itv : 2015-07-09 ITV Services Limited
 itv
 
-// iveco : 2015-09-03 CNH Industrial N.V.
-iveco
-
-// iwc : 2014-06-23 Richemont DNS Inc.
-iwc
-
 // jaguar : 2014-11-13 Jaguar Land Rover Ltd
 jaguar
 
@@ -8395,23 +8644,17 @@ java
 // jcb : 2014-11-20 JCB Co., Ltd.
 jcb
 
-// jcp : 2015-04-23 JCP Media, Inc.
-jcp
-
 // jeep : 2015-07-30 FCA US LLC.
 jeep
 
-// jetzt : 2014-01-09
+// jetzt : 2014-01-09 Binky Moon, LLC
 jetzt
 
-// jewelry : 2015-03-05 Wild Bloom, LLC
+// jewelry : 2015-03-05 Binky Moon, LLC
 jewelry
 
-// jio : 2015-04-02 Affinity Names, Inc.
+// jio : 2015-04-02 Reliance Industries Limited
 jio
-
-// jlc : 2014-12-04 Richemont DNS Inc.
-jlc
 
 // jll : 2015-04-02 Jones Lang LaSalle Incorporated
 jll
@@ -8425,25 +8668,25 @@ jnj
 // joburg : 2014-03-24 ZA Central Registry NPC trading as ZA Central Registry
 joburg
 
-// jot : 2014-12-18 Amazon EU S.à r.l.
+// jot : 2014-12-18 Amazon Registry Services, Inc.
 jot
 
-// joy : 2014-12-18 Amazon EU S.à r.l.
+// joy : 2014-12-18 Amazon Registry Services, Inc.
 joy
 
-// jpmorgan : 2015-04-30 JPMorgan Chase & Co.
+// jpmorgan : 2015-04-30 JPMorgan Chase Bank, National Association
 jpmorgan
 
 // jprs : 2014-09-18 Japan Registry Services Co., Ltd.
 jprs
 
-// juegos : 2014-03-20 Uniregistry, Corp.
+// juegos : 2014-03-20 UNR Corp.
 juegos
 
 // juniper : 2015-07-30 JUNIPER NETWORKS, INC.
 juniper
 
-// kaufen : 2013-11-07 United TLD Holdco Ltd.
+// kaufen : 2013-11-07 Dog Beach, LLC
 kaufen
 
 // kddi : 2014-09-12 KDDI CORPORATION
@@ -8464,22 +8707,25 @@ kfh
 // kia : 2015-07-09 KIA MOTORS CORPORATION
 kia
 
+// kids : 2021-08-13 DotKids Foundation Limited
+kids
+
 // kim : 2013-09-23 Afilias Limited
 kim
 
 // kinder : 2014-11-07 Ferrero Trading Lux S.A.
 kinder
 
-// kindle : 2015-06-25 Amazon EU S.à r.l.
+// kindle : 2015-06-25 Amazon Registry Services, Inc.
 kindle
 
-// kitchen : 2013-09-20 Just Goodbye, LLC
+// kitchen : 2013-09-20 Binky Moon, LLC
 kitchen
 
 // kiwi : 2013-09-20 DOT KIWI LIMITED
 kiwi
 
-// koeln : 2014-01-09 NetCologne Gesellschaft für Telekommunikation mbH
+// koeln : 2014-01-09 dotKoeln GmbH
 koeln
 
 // komatsu : 2015-01-08 Komatsu Ltd.
@@ -8506,11 +8752,8 @@ kuokgroup
 // kyoto : 2014-11-07 Academic Institution: Kyoto Jyoho Gakuen
 kyoto
 
-// lacaixa : 2014-01-09 CAIXA D'ESTALVIS I PENSIONS DE BARCELONA
+// lacaixa : 2014-01-09 Fundación Bancaria Caixa d’Estalvis i Pensions de Barcelona, “la Caixa”
 lacaixa
-
-// ladbrokes : 2015-08-06 LADBROKES INTERNATIONAL PLC
-ladbrokes
 
 // lamborghini : 2015-06-04 Automobili Lamborghini S.p.A.
 lamborghini
@@ -8524,10 +8767,7 @@ lancaster
 // lancia : 2015-07-31 Fiat Chrysler Automobiles N.V.
 lancia
 
-// lancome : 2015-07-23 L'Oréal
-lancome
-
-// land : 2013-09-10 Pine Moon, LLC
+// land : 2013-09-10 Binky Moon, LLC
 land
 
 // landrover : 2014-11-13 Jaguar Land Rover Ltd
@@ -8548,16 +8788,16 @@ latino
 // latrobe : 2014-06-16 La Trobe University
 latrobe
 
-// law : 2015-01-22 Minds + Machines Group Limited
+// law : 2015-01-22 Registry Services, LLC
 law
 
-// lawyer : 2014-03-20
+// lawyer : 2014-03-20 Dog Beach, LLC
 lawyer
 
-// lds : 2014-03-20 IRI Domain Management, LLC ("Applicant")
+// lds : 2014-03-20 IRI Domain Management, LLC
 lds
 
-// lease : 2014-03-06 Victor Trail, LLC
+// lease : 2014-03-06 Binky Moon, LLC
 lease
 
 // leclerc : 2014-08-07 A.C.D. LEC Association des Centres Distributeurs Edouard Leclerc
@@ -8566,7 +8806,7 @@ leclerc
 // lefrak : 2015-07-16 LeFrak Organization, Inc.
 lefrak
 
-// legal : 2014-10-16 Blue Falls, LLC
+// legal : 2014-10-16 Binky Moon, LLC
 legal
 
 // lego : 2015-07-16 LEGO Juris A/S
@@ -8578,13 +8818,10 @@ lexus
 // lgbt : 2014-05-08 Afilias Limited
 lgbt
 
-// liaison : 2014-10-02 Liaison Technologies, Incorporated
-liaison
-
 // lidl : 2014-09-18 Schwarz Domains und Services GmbH & Co. KG
 lidl
 
-// life : 2014-02-06 Trixy Oaks, LLC
+// life : 2014-02-06 Binky Moon, LLC
 life
 
 // lifeinsurance : 2015-01-15 American Council of Life Insurers
@@ -8593,19 +8830,19 @@ lifeinsurance
 // lifestyle : 2014-12-11 Lifestyle Domain Holdings, Inc.
 lifestyle
 
-// lighting : 2013-08-27 John McCook, LLC
+// lighting : 2013-08-27 Binky Moon, LLC
 lighting
 
-// like : 2014-12-18 Amazon EU S.à r.l.
+// like : 2014-12-18 Amazon Registry Services, Inc.
 like
 
 // lilly : 2015-07-31 Eli Lilly and Company
 lilly
 
-// limited : 2014-03-06 Big Fest, LLC
+// limited : 2014-03-06 Binky Moon, LLC
 limited
 
-// limo : 2013-10-17 Hidden Frostbite, LLC
+// limo : 2013-10-17 Binky Moon, LLC
 limo
 
 // lincoln : 2014-11-13 Ford Motor Company
@@ -8614,25 +8851,28 @@ lincoln
 // linde : 2014-12-04 Linde Aktiengesellschaft
 linde
 
-// link : 2013-11-14 Uniregistry, Corp.
+// link : 2013-11-14 UNR Corp.
 link
 
 // lipsy : 2015-06-25 Lipsy Ltd
 lipsy
 
-// live : 2014-12-04
+// live : 2014-12-04 Dog Beach, LLC
 live
 
 // living : 2015-07-30 Lifestyle Domain Holdings, Inc.
 living
 
-// lixil : 2015-03-19 LIXIL Group Corporation
-lixil
+// llc : 2017-12-14 Afilias Limited
+llc
+
+// llp : 2019-08-26 UNR Corp.
+llp
 
 // loan : 2014-11-20 dot Loan Limited
 loan
 
-// loans : 2014-03-20 June Woods, LLC
+// loans : 2014-03-20 Binky Moon, LLC
 loans
 
 // locker : 2015-06-04 Dish DBS Corporation
@@ -8644,7 +8884,7 @@ locus
 // loft : 2015-07-30 Annco, Inc.
 loft
 
-// lol : 2015-01-30 Uniregistry, Corp.
+// lol : 2015-01-30 XYZ.COM LLC
 lol
 
 // london : 2013-11-14 Dot London Domains Limited
@@ -8665,19 +8905,16 @@ lpl
 // lplfinancial : 2015-07-30 LPL Holdings, Inc.
 lplfinancial
 
-// ltd : 2014-09-25 Over Corner, LLC
+// ltd : 2014-09-25 Binky Moon, LLC
 ltd
 
-// ltda : 2014-04-17 DOMAIN ROBOT SERVICOS DE HOSPEDAGEM NA INTERNET LTDA
+// ltda : 2014-04-17 InterNetX, Corp
 ltda
 
 // lundbeck : 2015-08-06 H. Lundbeck A/S
 lundbeck
 
-// lupin : 2014-11-07 LUPIN LIMITED
-lupin
-
-// luxe : 2014-01-09 Top Level Domain Holdings Limited
+// luxe : 2014-01-09 Registry Services, LLC
 luxe
 
 // luxury : 2013-10-17 Luxury Partners, LLC
@@ -8692,16 +8929,16 @@ madrid
 // maif : 2014-10-02 Mutuelle Assurance Instituteur France (MAIF)
 maif
 
-// maison : 2013-12-05 Victor Frostbite, LLC
+// maison : 2013-12-05 Binky Moon, LLC
 maison
 
-// makeup : 2015-01-15 L'Oréal
+// makeup : 2015-01-15 XYZ.COM LLC
 makeup
 
 // man : 2014-12-04 MAN SE
 man
 
-// management : 2013-11-07 John Goodbye, LLC
+// management : 2013-11-07 Binky Moon, LLC
 management
 
 // mango : 2013-10-24 PUNTO FA S.L.
@@ -8710,13 +8947,13 @@ mango
 // map : 2016-06-09 Charleston Road Registry Inc.
 map
 
-// market : 2014-03-06
+// market : 2014-03-06 Dog Beach, LLC
 market
 
-// marketing : 2013-11-07 Fern Pass, LLC
+// marketing : 2013-11-07 Binky Moon, LLC
 marketing
 
-// markets : 2014-12-11 IG Group Holdings PLC
+// markets : 2014-12-11 Dog Beach, LLC
 markets
 
 // marriott : 2014-10-09 Marriott Worldwide Corporation
@@ -8731,14 +8968,8 @@ maserati
 // mattel : 2015-08-06 Mattel Sites, Inc.
 mattel
 
-// mba : 2015-04-02 Lone Hollow, LLC
+// mba : 2015-04-02 Binky Moon, LLC
 mba
-
-// mcd : 2015-07-30 McDonald’s Corporation
-mcd
-
-// mcdonalds : 2015-07-30 McDonald’s Corporation
-mcdonalds
 
 // mckinsey : 2015-07-31 McKinsey Holdings, Inc.
 mckinsey
@@ -8746,10 +8977,10 @@ mckinsey
 // med : 2015-08-06 Medistry LLC
 med
 
-// media : 2014-03-06 Grand Glen, LLC
+// media : 2014-03-06 Binky Moon, LLC
 media
 
-// meet : 2014-01-16
+// meet : 2014-01-16 Charleston Road Registry Inc.
 meet
 
 // melbourne : 2014-05-29 The Crown in right of the State of Victoria, represented by its Department of State Development, Business and Innovation
@@ -8764,19 +8995,13 @@ memorial
 // men : 2015-02-26 Exclusive Registry Limited
 men
 
-// menu : 2013-09-11 Wedding TLD2, LLC
+// menu : 2013-09-11 Dot Menu Registry, LLC
 menu
-
-// meo : 2014-11-07 PT Comunicacoes S.A.
-meo
 
 // merckmsd : 2016-07-14 MSD Registry Holdings, Inc.
 merckmsd
 
-// metlife : 2015-05-07 MetLife Services and Solutions, LLC
-metlife
-
-// miami : 2013-12-19 Top Level Domain Holdings Limited
+// miami : 2013-12-19 Registry Services, LLC
 miami
 
 // microsoft : 2014-12-18 Microsoft Corporation
@@ -8806,59 +9031,47 @@ mma
 // mobile : 2016-06-02 Dish DBS Corporation
 mobile
 
-// mobily : 2014-12-18 GreenTech Consultancy Company W.L.L.
-mobily
-
-// moda : 2013-11-07 United TLD Holdco Ltd.
+// moda : 2013-11-07 Dog Beach, LLC
 moda
 
 // moe : 2013-11-13 Interlink Co., Ltd.
 moe
 
-// moi : 2014-12-18 Amazon EU S.à r.l.
+// moi : 2014-12-18 Amazon Registry Services, Inc.
 moi
 
-// mom : 2015-04-16 Uniregistry, Corp.
+// mom : 2015-04-16 XYZ.COM LLC
 mom
 
 // monash : 2013-09-30 Monash University
 monash
 
-// money : 2014-10-16 Outer McCook, LLC
+// money : 2014-10-16 Binky Moon, LLC
 money
 
-// monster : 2015-09-11 Monster Worldwide, Inc.
+// monster : 2015-09-11 XYZ.COM LLC
 monster
 
-// montblanc : 2014-06-23 Richemont DNS Inc.
-montblanc
-
-// mopar : 2015-07-30 FCA US LLC.
-mopar
-
-// mormon : 2013-12-05 IRI Domain Management, LLC ("Applicant")
+// mormon : 2013-12-05 IRI Domain Management, LLC
 mormon
 
-// mortgage : 2014-03-20
+// mortgage : 2014-03-20 Dog Beach, LLC
 mortgage
 
 // moscow : 2013-12-19 Foundation for Assistance for Internet Technologies and Infrastructure Development (FAITID)
 moscow
 
-// moto : 2015-06-04
+// moto : 2015-06-04 Motorola Trademark Holdings, LLC
 moto
 
-// motorcycles : 2014-01-09 DERMotorcycles, LLC
+// motorcycles : 2014-01-09 XYZ.COM LLC
 motorcycles
 
 // mov : 2014-01-30 Charleston Road Registry Inc.
 mov
 
-// movie : 2015-02-05 New Frostbite, LLC
+// movie : 2015-02-05 Binky Moon, LLC
 movie
-
-// movistar : 2014-10-16 Telefónica S.A.
-movistar
 
 // msd : 2015-07-23 MSD Registry Holdings, Inc.
 msd
@@ -8866,11 +9079,11 @@ msd
 // mtn : 2014-12-04 MTN Dubai Limited
 mtn
 
-// mtpc : 2014-11-20 Mitsubishi Tanabe Pharma Corporation
-mtpc
-
 // mtr : 2015-03-12 MTR Corporation Limited
 mtr
+
+// music : 2021-05-04 DotMusic Limited
+music
 
 // mutual : 2015-04-02 Northwestern Mutual MU TLD Registry, LLC
 mutual
@@ -8878,19 +9091,13 @@ mutual
 // nab : 2015-08-20 National Australia Bank Limited
 nab
 
-// nadex : 2014-12-11 IG Group Holdings PLC
-nadex
-
 // nagoya : 2013-10-24 GMO Registry, Inc.
 nagoya
-
-// nationwide : 2015-07-23 Nationwide Mutual Insurance Company
-nationwide
 
 // natura : 2015-03-12 NATURA COSMÉTICOS S.A.
 natura
 
-// navy : 2014-03-06 United TLD Holdco Ltd.
+// navy : 2014-03-06 Dog Beach, LLC
 navy
 
 // nba : 2015-07-31 NBA REGISTRY, LLC
@@ -8905,7 +9112,7 @@ netbank
 // netflix : 2015-06-18 Netflix, Inc.
 netflix
 
-// network : 2013-11-14 Trixy Manor, LLC
+// network : 2013-11-14 Binky Moon, LLC
 network
 
 // neustar : 2013-12-05 NeuStar, Inc.
@@ -8914,10 +9121,7 @@ neustar
 // new : 2014-01-30 Charleston Road Registry Inc.
 new
 
-// newholland : 2015-09-03 CNH Industrial N.V.
-newholland
-
-// news : 2014-12-18
+// news : 2014-12-18 Dog Beach, LLC
 news
 
 // next : 2015-06-18 Next plc
@@ -8947,7 +9151,7 @@ nike
 // nikon : 2015-05-21 NIKON CORPORATION
 nikon
 
-// ninja : 2013-11-07 United TLD Holdco Ltd.
+// ninja : 2013-11-07 Dog Beach, LLC
 ninja
 
 // nissan : 2014-03-27 NISSAN MOTOR CO., LTD.
@@ -8962,10 +9166,10 @@ nokia
 // northwesternmutual : 2015-06-18 Northwestern Mutual Registry, LLC
 northwesternmutual
 
-// norton : 2014-12-04 Symantec Corporation
+// norton : 2014-12-04 NortonLifeLock Inc.
 norton
 
-// now : 2015-06-25 Amazon EU S.à r.l.
+// now : 2015-06-25 Amazon Registry Services, Inc.
 now
 
 // nowruz : 2014-09-04 Asia Green IT System Bilgisayar San. ve Tic. Ltd. Sti.
@@ -8989,16 +9193,13 @@ nyc
 // obi : 2014-09-25 OBI Group Holding SE & Co. KGaA
 obi
 
-// observer : 2015-04-30
+// observer : 2015-04-30 Dog Beach, LLC
 observer
-
-// off : 2015-07-23 Johnson Shareholdings, Inc.
-off
 
 // office : 2015-03-12 Microsoft Corporation
 office
 
-// okinawa : 2013-12-05 BusinessRalliart Inc.
+// okinawa : 2013-12-05 BRregistry, Inc.
 okinawa
 
 // olayan : 2015-05-14 Crescent Holding GmbH
@@ -9022,16 +9223,13 @@ one
 // ong : 2014-03-06 Public Interest Registry
 ong
 
-// onl : 2013-09-16 I-Registry Ltd.
+// onl : 2013-09-16 iRegistry GmbH
 onl
 
-// online : 2015-01-15 DotOnline Inc.
+// online : 2015-01-15 Radix FZC
 online
 
-// onyourside : 2015-07-23 Nationwide Mutual Insurance Company
-onyourside
-
-// ooo : 2014-01-09 INFIBEAM INCORPORATION LIMITED
+// ooo : 2014-01-09 INFIBEAM AVENUES LIMITED
 ooo
 
 // open : 2015-07-31 American Express Travel Related Services Company, Inc.
@@ -9046,13 +9244,10 @@ orange
 // organic : 2014-03-27 Afilias Limited
 organic
 
-// orientexpress : 2015-02-05
-orientexpress
-
 // origins : 2015-10-01 The Estée Lauder Companies Inc.
 origins
 
-// osaka : 2014-09-04 Interlink Co., Ltd.
+// osaka : 2014-09-04 Osaka Registry Co., Ltd.
 osaka
 
 // otsuka : 2013-10-11 Otsuka Holdings Co., Ltd.
@@ -9061,20 +9256,14 @@ otsuka
 // ott : 2015-06-04 Dish DBS Corporation
 ott
 
-// ovh : 2014-01-16 OVH SAS
+// ovh : 2014-01-16 MédiaBC
 ovh
 
 // page : 2014-12-04 Charleston Road Registry Inc.
 page
 
-// pamperedchef : 2015-02-05 The Pampered Chef, Ltd.
-pamperedchef
-
 // panasonic : 2015-07-30 Panasonic Corporation
 panasonic
-
-// panerai : 2014-11-07 Richemont DNS Inc.
-panerai
 
 // paris : 2014-01-30 City of Paris
 paris
@@ -9082,10 +9271,10 @@ paris
 // pars : 2014-09-04 Asia Green IT System Bilgisayar San. ve Tic. Ltd. Sti.
 pars
 
-// partners : 2013-12-05 Magic Glen, LLC
+// partners : 2013-12-05 Binky Moon, LLC
 partners
 
-// parts : 2013-12-05 Sea Goodbye, LLC
+// parts : 2013-12-05 Binky Moon, LLC
 parts
 
 // party : 2014-09-11 Blue Sky Registry Limited
@@ -9094,13 +9283,13 @@ party
 // passagens : 2015-03-05 Travel Reservations SRL
 passagens
 
-// pay : 2015-08-27 Amazon EU S.à r.l.
+// pay : 2015-08-27 Amazon Registry Services, Inc.
 pay
 
 // pccw : 2015-05-14 PCCW Enterprises Limited
 pccw
 
-// pet : 2015-05-07 Afilias plc
+// pet : 2015-05-07 Afilias Limited
 pet
 
 // pfizer : 2015-09-11 Pfizer Inc.
@@ -9118,34 +9307,31 @@ philips
 // phone : 2016-06-02 Dish DBS Corporation
 phone
 
-// photo : 2013-11-14 Uniregistry, Corp.
+// photo : 2013-11-14 Registry Services, LLC
 photo
 
-// photography : 2013-09-20 Sugar Glen, LLC
+// photography : 2013-09-20 Binky Moon, LLC
 photography
 
-// photos : 2013-10-17 Sea Corner, LLC
+// photos : 2013-10-17 Binky Moon, LLC
 photos
 
 // physio : 2014-05-01 PhysBiz Pty Ltd
 physio
 
-// piaget : 2014-10-16 Richemont DNS Inc.
-piaget
-
-// pics : 2013-11-14 Uniregistry, Corp.
+// pics : 2013-11-14 XYZ.COM LLC
 pics
 
 // pictet : 2014-06-26 Pictet Europe S.A.
 pictet
 
-// pictures : 2014-03-06 Foggy Sky, LLC
+// pictures : 2014-03-06 Binky Moon, LLC
 pictures
 
 // pid : 2015-01-08 Top Level Spectrum, Inc.
 pid
 
-// pin : 2014-12-18 Amazon EU S.à r.l.
+// pin : 2014-12-18 Amazon Registry Services, Inc.
 pin
 
 // ping : 2015-06-11 Ping Registry Provider, Inc.
@@ -9157,22 +9343,22 @@ pink
 // pioneer : 2015-07-16 Pioneer Corporation
 pioneer
 
-// pizza : 2014-06-26 Foggy Moon, LLC
+// pizza : 2014-06-26 Binky Moon, LLC
 pizza
 
-// place : 2014-04-24 Snow Galley, LLC
+// place : 2014-04-24 Binky Moon, LLC
 place
 
 // play : 2015-03-05 Charleston Road Registry Inc.
 play
 
-// playstation : 2015-07-02 Sony Computer Entertainment Inc.
+// playstation : 2015-07-02 Sony Interactive Entertainment Inc.
 playstation
 
-// plumbing : 2013-09-10 Spring Tigers, LLC
+// plumbing : 2013-09-10 Binky Moon, LLC
 plumbing
 
-// plus : 2015-02-05 Sugar Mill, LLC
+// plus : 2015-02-05 Binky Moon, LLC
 plus
 
 // pnc : 2015-07-02 PNC Domain Co., LLC
@@ -9181,7 +9367,7 @@ pnc
 // pohl : 2014-06-23 Deutsche Vermögensberatung Aktiengesellschaft DVAG
 pohl
 
-// poker : 2014-07-03 Afilias Domains No. 5 Limited
+// poker : 2014-07-03 Afilias Limited
 poker
 
 // politie : 2015-08-20 Politie Nederland
@@ -9196,16 +9382,16 @@ pramerica
 // praxi : 2013-12-05 Praxi S.p.A.
 praxi
 
-// press : 2014-04-03 DotPress Inc.
+// press : 2014-04-03 Radix FZC
 press
 
-// prime : 2015-06-25 Amazon EU S.à r.l.
+// prime : 2015-06-25 Amazon Registry Services, Inc.
 prime
 
 // prod : 2014-01-23 Charleston Road Registry Inc.
 prod
 
-// productions : 2013-12-05 Magic Birch, LLC
+// productions : 2013-12-05 Binky Moon, LLC
 productions
 
 // prof : 2014-07-24 Charleston Road Registry Inc.
@@ -9214,16 +9400,16 @@ prof
 // progressive : 2015-07-23 Progressive Casualty Insurance Company
 progressive
 
-// promo : 2014-12-18
+// promo : 2014-12-18 Afilias Limited
 promo
 
-// properties : 2013-12-05 Big Pass, LLC
+// properties : 2013-12-05 Binky Moon, LLC
 properties
 
-// property : 2014-05-22 Uniregistry, Corp.
+// property : 2014-05-22 UNR Corp.
 property
 
-// protection : 2015-04-23
+// protection : 2015-04-23 XYZ.COM LLC
 protection
 
 // pru : 2015-07-30 Prudential Financial, Inc.
@@ -9232,7 +9418,7 @@ pru
 // prudential : 2015-07-30 Prudential Financial, Inc.
 prudential
 
-// pub : 2013-12-12 United TLD Holdco Ltd.
+// pub : 2013-12-12 Dog Beach, LLC
 pub
 
 // pwc : 2015-10-29 PricewaterhouseCoopers LLP
@@ -9244,11 +9430,8 @@ qpon
 // quebec : 2013-12-19 PointQuébec Inc
 quebec
 
-// quest : 2015-03-26 Quest ION Limited
+// quest : 2015-03-26 XYZ.COM LLC
 quest
-
-// qvc : 2015-07-30 QVC, Inc.
-qvc
 
 // racing : 2014-12-04 Premier Registry Limited
 racing
@@ -9256,10 +9439,7 @@ racing
 // radio : 2016-07-21 European Broadcasting Union (EBU)
 radio
 
-// raid : 2015-07-23 Johnson Shareholdings, Inc.
-raid
-
-// read : 2014-12-18 Amazon EU S.à r.l.
+// read : 2014-12-18 Amazon Registry Services, Inc.
 read
 
 // realestate : 2015-09-11 dotRealEstate LLC
@@ -9268,10 +9448,10 @@ realestate
 // realtor : 2014-05-29 Real Estate Domains LLC
 realtor
 
-// realty : 2015-03-19 Fegistry, LLC
+// realty : 2015-03-19 Dog Beach, LLC
 realty
 
-// recipes : 2013-10-17 Grand Island, LLC
+// recipes : 2013-10-17 Binky Moon, LLC
 recipes
 
 // red : 2013-11-07 Afilias Limited
@@ -9283,13 +9463,13 @@ redstone
 // redumbrella : 2015-03-26 Travelers TLD, LLC
 redumbrella
 
-// rehab : 2014-03-06 United TLD Holdco Ltd.
+// rehab : 2014-03-06 Dog Beach, LLC
 rehab
 
-// reise : 2014-03-13
+// reise : 2014-03-13 Binky Moon, LLC
 reise
 
-// reisen : 2014-03-06 New Cypress, LLC
+// reisen : 2014-03-06 Binky Moon, LLC
 reisen
 
 // reit : 2014-09-04 National Association of Real Estate Investment Trusts, Inc.
@@ -9298,40 +9478,40 @@ reit
 // reliance : 2015-04-02 Reliance Industries Limited
 reliance
 
-// ren : 2013-12-12 Beijing Qianxiang Wangjing Technology Development Co., Ltd.
+// ren : 2013-12-12 ZDNS International Limited
 ren
 
-// rent : 2014-12-04 DERRent, LLC
+// rent : 2014-12-04 XYZ.COM LLC
 rent
 
-// rentals : 2013-12-05 Big Hollow,LLC
+// rentals : 2013-12-05 Binky Moon, LLC
 rentals
 
-// repair : 2013-11-07 Lone Sunset, LLC
+// repair : 2013-11-07 Binky Moon, LLC
 repair
 
-// report : 2013-12-05 Binky Glen, LLC
+// report : 2013-12-05 Binky Moon, LLC
 report
 
-// republican : 2014-03-20 United TLD Holdco Ltd.
+// republican : 2014-03-20 Dog Beach, LLC
 republican
 
 // rest : 2013-12-19 Punto 2012 Sociedad Anonima Promotora de Inversion de Capital Variable
 rest
 
-// restaurant : 2014-07-03 Snow Avenue, LLC
+// restaurant : 2014-07-03 Binky Moon, LLC
 restaurant
 
 // review : 2014-11-20 dot Review Limited
 review
 
-// reviews : 2013-09-13
+// reviews : 2013-09-13 Dog Beach, LLC
 reviews
 
 // rexroth : 2015-06-18 Robert Bosch GMBH
 rexroth
 
-// rich : 2013-11-21 I-Registry Ltd.
+// rich : 2013-11-21 iRegistry GmbH
 rich
 
 // richardli : 2015-05-14 Pacific Century Asset Management (HK) Limited
@@ -9340,34 +9520,28 @@ richardli
 // ricoh : 2014-11-20 Ricoh Company, Ltd.
 ricoh
 
-// rightathome : 2015-07-23 Johnson Shareholdings, Inc.
-rightathome
-
 // ril : 2015-04-02 Reliance Industries Limited
 ril
 
 // rio : 2014-02-27 Empresa Municipal de Informática SA - IPLANRIO
 rio
 
-// rip : 2014-07-10 United TLD Holdco Ltd.
+// rip : 2014-07-10 Dog Beach, LLC
 rip
-
-// rmit : 2015-11-19 Royal Melbourne Institute of Technology
-rmit
 
 // rocher : 2014-12-18 Ferrero Trading Lux S.A.
 rocher
 
-// rocks : 2013-11-14
+// rocks : 2013-11-14 Dog Beach, LLC
 rocks
 
-// rodeo : 2013-12-19 Top Level Domain Holdings Limited
+// rodeo : 2013-12-19 Registry Services, LLC
 rodeo
 
-// rogers : 2015-08-06 Rogers Communications Partnership
+// rogers : 2015-08-06 Rogers Communications Canada Inc.
 rogers
 
-// room : 2014-12-18 Amazon EU S.à r.l.
+// room : 2014-12-18 Amazon Registry Services, Inc.
 room
 
 // rsvp : 2014-05-08 Charleston Road Registry Inc.
@@ -9376,22 +9550,22 @@ rsvp
 // rugby : 2016-12-15 World Rugby Strategic Developments Limited
 rugby
 
-// ruhr : 2013-10-02 regiodot GmbH & Co. KG
+// ruhr : 2013-10-02 dotSaarland GmbH
 ruhr
 
-// run : 2015-03-19 Snow Park, LLC
+// run : 2015-03-19 Binky Moon, LLC
 run
 
 // rwe : 2015-04-02 RWE AG
 rwe
 
-// ryukyu : 2014-01-09 BusinessRalliart Inc.
+// ryukyu : 2014-01-09 BRregistry, Inc.
 ryukyu
 
 // saarland : 2013-12-12 dotSaarland GmbH
 saarland
 
-// safe : 2014-12-18 Amazon EU S.à r.l.
+// safe : 2014-12-18 Amazon Registry Services, Inc.
 safe
 
 // safety : 2015-01-08 Safety Registry Services, LLC.
@@ -9400,10 +9574,10 @@ safety
 // sakura : 2014-12-18 SAKURA Internet Inc.
 sakura
 
-// sale : 2014-10-16
+// sale : 2014-10-16 Dog Beach, LLC
 sale
 
-// salon : 2014-12-11 Outer Orchard, LLC
+// salon : 2014-12-11 Binky Moon, LLC
 salon
 
 // samsclub : 2015-07-31 Wal-Mart Stores, Inc.
@@ -9424,16 +9598,13 @@ sanofi
 // sap : 2014-03-27 SAP AG
 sap
 
-// sapo : 2014-11-07 PT Comunicacoes S.A.
-sapo
-
-// sarl : 2014-07-03 Delta Orchard, LLC
+// sarl : 2014-07-03 Binky Moon, LLC
 sarl
 
 // sas : 2015-04-02 Research IP LLC
 sas
 
-// save : 2015-06-25 Amazon EU S.à r.l.
+// save : 2015-06-25 Amazon Registry Services, Inc.
 save
 
 // saxo : 2014-10-31 Saxo Bank A/S
@@ -9442,7 +9613,7 @@ saxo
 // sbi : 2015-03-12 STATE BANK OF INDIA
 sbi
 
-// sbs : 2014-11-07 SPECIAL BROADCASTING SERVICE CORPORATION
+// sbs : 2014-11-07 ShortDot SA
 sbs
 
 // sca : 2014-03-13 SVENSKA CELLULOSA AKTIEBOLAGET SCA (publ)
@@ -9454,16 +9625,16 @@ scb
 // schaeffler : 2015-08-06 Schaeffler Technologies AG & Co. KG
 schaeffler
 
-// schmidt : 2014-04-03 SALM S.A.S.
+// schmidt : 2014-04-03 SCHMIDT GROUPE S.A.S.
 schmidt
 
 // scholarships : 2014-04-24 Scholarships.com, LLC
 scholarships
 
-// school : 2014-12-18 Little Galley, LLC
+// school : 2014-12-18 Binky Moon, LLC
 school
 
-// schule : 2014-03-06 Outer Moon, LLC
+// schule : 2014-03-06 Binky Moon, LLC
 schule
 
 // schwarz : 2014-09-18 Schwarz Domains und Services GmbH & Co. KG
@@ -9471,12 +9642,6 @@ schwarz
 
 // science : 2014-09-11 dot Science Limited
 science
-
-// scjohnson : 2015-07-23 Johnson Shareholdings, Inc.
-scjohnson
-
-// scor : 2014-10-31 SCOR SE
-scor
 
 // scot : 2014-01-23 Dot Scot Registry Limited
 scot
@@ -9487,22 +9652,22 @@ search
 // seat : 2014-05-22 SEAT, S.A. (Sociedad Unipersonal)
 seat
 
-// secure : 2015-08-27 Amazon EU S.à r.l.
+// secure : 2015-08-27 Amazon Registry Services, Inc.
 secure
 
-// security : 2015-05-14
+// security : 2015-05-14 XYZ.COM LLC
 security
 
 // seek : 2014-12-04 Seek Limited
 seek
 
-// select : 2015-10-08 iSelect Ltd
+// select : 2015-10-08 Registry Services, LLC
 select
 
 // sener : 2014-10-24 Sener Ingeniería y Sistemas, S.A.
 sener
 
-// services : 2014-02-27 Fox Castle, LLC
+// services : 2014-02-27 Binky Moon, LLC
 services
 
 // ses : 2015-07-23 SES
@@ -9517,7 +9682,7 @@ sew
 // sex : 2014-11-13 ICM Registry SX LLC
 sex
 
-// sexy : 2013-09-11 Uniregistry, Corp.
+// sexy : 2013-09-11 UNR Corp.
 sexy
 
 // sfr : 2015-08-13 Societe Francaise du Radiotelephone - SFR
@@ -9541,85 +9706,82 @@ shia
 // shiksha : 2013-11-14 Afilias Limited
 shiksha
 
-// shoes : 2013-10-02 Binky Galley, LLC
+// shoes : 2013-10-02 Binky Moon, LLC
 shoes
 
 // shop : 2016-04-08 GMO Registry, Inc.
 shop
 
-// shopping : 2016-03-31
+// shopping : 2016-03-31 Binky Moon, LLC
 shopping
 
-// shouji : 2015-01-08 QIHOO 360 TECHNOLOGY CO. LTD.
+// shouji : 2015-01-08 Beijing Qihu Keji Co., Ltd.
 shouji
 
-// show : 2015-03-05 Snow Beach, LLC
+// show : 2015-03-05 Binky Moon, LLC
 show
 
 // showtime : 2015-08-06 CBS Domains Inc.
 showtime
 
-// shriram : 2014-01-23 Shriram Capital Ltd.
-shriram
-
-// silk : 2015-06-25 Amazon EU S.à r.l.
+// silk : 2015-06-25 Amazon Registry Services, Inc.
 silk
 
 // sina : 2015-03-12 Sina Corporation
 sina
 
-// singles : 2013-08-27 Fern Madison, LLC
+// singles : 2013-08-27 Binky Moon, LLC
 singles
 
-// site : 2015-01-15 DotSite Inc.
+// site : 2015-01-15 Radix FZC
 site
 
-// ski : 2015-04-09 STARTING DOT LIMITED
+// ski : 2015-04-09 Afilias Limited
 ski
 
-// skin : 2015-01-15 L'Oréal
+// skin : 2015-01-15 XYZ.COM LLC
 skin
 
-// sky : 2014-06-19 Sky IP International Ltd, a company incorporated in England and Wales, operating via its registered Swiss branch
+// sky : 2014-06-19 Sky International AG
 sky
 
 // skype : 2014-12-18 Microsoft Corporation
 skype
 
-// sling : 2015-07-30 Hughes Satellite Systems Corporation
+// sling : 2015-07-30 DISH Technologies L.L.C.
 sling
 
 // smart : 2015-07-09 Smart Communications, Inc. (SMART)
 smart
 
-// smile : 2014-12-18 Amazon EU S.à r.l.
+// smile : 2014-12-18 Amazon Registry Services, Inc.
 smile
 
 // sncf : 2015-02-19 Société Nationale des Chemins de fer Francais S N C F
 sncf
 
-// soccer : 2015-03-26 Foggy Shadow, LLC
+// soccer : 2015-03-26 Binky Moon, LLC
 soccer
 
-// social : 2013-11-07 United TLD Holdco Ltd.
+// social : 2013-11-07 Dog Beach, LLC
 social
 
-// softbank : 2015-07-02 SoftBank Corp.
+// softbank : 2015-07-02 SoftBank Group Corp.
 softbank
 
-// software : 2014-03-20
+// software : 2014-03-20 Dog Beach, LLC
 software
 
 // sohu : 2013-12-19 Sohu.com Limited
 sohu
 
-// solar : 2013-11-07 Ruby Town, LLC
+// solar : 2013-11-07 Binky Moon, LLC
 solar
 
-// solutions : 2013-11-07 Silver Cover, LLC
+// solutions : 2013-11-07 Binky Moon, LLC
 solutions
 
-// song : 2015-02-26 Amazon EU S.à r.l.
+// song : 2015-02-26 Amazon Registry Services, Inc.
 song
 
 // sony : 2015-01-08 Sony Corporation
@@ -9628,23 +9790,20 @@ sony
 // soy : 2014-01-23 Charleston Road Registry Inc.
 soy
 
-// space : 2014-04-03 DotSpace Inc.
+// spa : 2019-09-19 Asia Spa and Wellness Promotion Council Limited
+spa
+
+// space : 2014-04-03 Radix FZC
 space
 
-// spiegel : 2014-02-05 SPIEGEL-Verlag Rudolf Augstein GmbH & Co. KG
-spiegel
+// sport : 2017-11-16 Global Association of International Sports Federations (GAISF)
+sport
 
-// spot : 2015-02-26 Amazon EU S.à r.l.
+// spot : 2015-02-26 Amazon Registry Services, Inc.
 spot
 
-// spreadbetting : 2014-12-11 IG Group Holdings PLC
-spreadbetting
-
-// srl : 2015-05-07 mySRL GmbH
+// srl : 2015-05-07 InterNetX, Corp
 srl
-
-// srt : 2015-07-30 FCA US LLC.
-srt
 
 // stada : 2014-11-13 STADA Arzneimittel AG
 stada
@@ -9655,17 +9814,11 @@ staples
 // star : 2015-01-08 Star India Private Limited
 star
 
-// starhub : 2015-02-05 StarHub Ltd
-starhub
-
 // statebank : 2015-03-12 STATE BANK OF INDIA
 statebank
 
 // statefarm : 2015-07-30 State Farm Mutual Automobile Insurance Company
 statefarm
-
-// statoil : 2014-12-04 Statoil ASA
-statoil
 
 // stc : 2014-10-09 Saudi Telecom Company
 stc
@@ -9676,16 +9829,16 @@ stcgroup
 // stockholm : 2014-12-18 Stockholms kommun
 stockholm
 
-// storage : 2014-12-22 Self Storage Company LLC
+// storage : 2014-12-22 XYZ.COM LLC
 storage
 
-// store : 2015-04-09 DotStore Inc.
+// store : 2015-04-09 Radix FZC
 store
 
 // stream : 2016-01-08 dot Stream Limited
 stream
 
-// studio : 2015-02-11
+// studio : 2015-02-11 Dog Beach, LLC
 studio
 
 // study : 2014-12-11 OPEN UNIVERSITIES AUSTRALIA PTY LTD
@@ -9694,22 +9847,22 @@ study
 // style : 2014-12-04 Binky Moon, LLC
 style
 
-// sucks : 2014-12-22 Vox Populi Registry Inc.
+// sucks : 2014-12-22 Vox Populi Registry Ltd.
 sucks
 
-// supplies : 2013-12-19 Atomic Fields, LLC
+// supplies : 2013-12-19 Binky Moon, LLC
 supplies
 
-// supply : 2013-12-19 Half Falls, LLC
+// supply : 2013-12-19 Binky Moon, LLC
 supply
 
-// support : 2013-10-24 Grand Orchard, LLC
+// support : 2013-10-24 Binky Moon, LLC
 support
 
-// surf : 2014-01-09 Top Level Domain Holdings Limited
+// surf : 2014-01-09 Registry Services, LLC
 surf
 
-// surgery : 2014-03-20 Tin Avenue, LLC
+// surgery : 2014-03-20 Binky Moon, LLC
 surgery
 
 // suzuki : 2014-02-20 SUZUKI MOTOR CORPORATION
@@ -9718,19 +9871,13 @@ suzuki
 // swatch : 2015-01-08 The Swatch Group Ltd
 swatch
 
-// swiftcover : 2015-07-23 Swiftcover Insurance Services Limited
-swiftcover
-
 // swiss : 2014-10-16 Swiss Confederation
 swiss
 
 // sydney : 2014-09-18 State of New South Wales, Department of Premier and Cabinet
 sydney
 
-// symantec : 2014-12-04 Symantec Corporation
-symantec
-
-// systems : 2013-11-07 Dash Cypress, LLC
+// systems : 2013-11-07 Binky Moon, LLC
 systems
 
 // tab : 2014-12-04 Tabcorp Holdings Limited
@@ -9739,7 +9886,7 @@ tab
 // taipei : 2014-07-10 Taipei City Government
 taipei
 
-// talk : 2015-04-09 Amazon EU S.à r.l.
+// talk : 2015-04-09 Amazon Registry Services, Inc.
 talk
 
 // taobao : 2015-01-15 Alibaba Group Holding Limited
@@ -9754,13 +9901,13 @@ tatamotors
 // tatar : 2014-04-24 Limited Liability Company "Coordination Center of Regional Domain of Tatarstan Republic"
 tatar
 
-// tattoo : 2013-08-30 Uniregistry, Corp.
+// tattoo : 2013-08-30 UNR Corp.
 tattoo
 
-// tax : 2014-03-20 Storm Orchard, LLC
+// tax : 2014-03-20 Binky Moon, LLC
 tax
 
-// taxi : 2015-03-19 Pine Falls, LLC
+// taxi : 2015-03-19 Binky Moon, LLC
 taxi
 
 // tci : 2014-09-12 Asia Green IT System Bilgisayar San. ve Tic. Ltd. Sti.
@@ -9769,55 +9916,49 @@ tci
 // tdk : 2015-06-11 TDK Corporation
 tdk
 
-// team : 2015-03-05 Atomic Lake, LLC
+// team : 2015-03-05 Binky Moon, LLC
 team
 
-// tech : 2015-01-30 Dot Tech LLC
+// tech : 2015-01-30 Radix FZC
 tech
 
-// technology : 2013-09-13 Auburn Falls
+// technology : 2013-09-13 Binky Moon, LLC
 technology
-
-// telecity : 2015-02-19 TelecityGroup International Limited
-telecity
-
-// telefonica : 2014-10-16 Telefónica S.A.
-telefonica
 
 // temasek : 2014-08-07 Temasek Holdings (Private) Limited
 temasek
 
-// tennis : 2014-12-04 Cotton Bloom, LLC
+// tennis : 2014-12-04 Binky Moon, LLC
 tennis
 
 // teva : 2015-07-02 Teva Pharmaceutical Industries Limited
 teva
 
-// thd : 2015-04-02 Homer TLC, Inc.
+// thd : 2015-04-02 Home Depot Product Authority, LLC
 thd
 
-// theater : 2015-03-19 Blue Tigers, LLC
+// theater : 2015-03-19 Binky Moon, LLC
 theater
 
-// theatre : 2015-05-07
+// theatre : 2015-05-07 XYZ.COM LLC
 theatre
 
 // tiaa : 2015-07-23 Teachers Insurance and Annuity Association of America
 tiaa
 
-// tickets : 2015-02-05 Accent Media Limited
+// tickets : 2015-02-05 XYZ.COM LLC
 tickets
 
-// tienda : 2013-11-14 Victor Manor, LLC
+// tienda : 2013-11-14 Binky Moon, LLC
 tienda
 
 // tiffany : 2015-01-30 Tiffany and Company
 tiffany
 
-// tips : 2013-09-20 Corn Willow, LLC
+// tips : 2013-09-20 Binky Moon, LLC
 tips
 
-// tires : 2014-11-07 Dog Edge, LLC
+// tires : 2014-11-07 Binky Moon, LLC
 tires
 
 // tirol : 2014-04-24 punkt Tirol GmbH
@@ -9835,16 +9976,16 @@ tkmaxx
 // tmall : 2015-01-15 Alibaba Group Holding Limited
 tmall
 
-// today : 2013-09-20 Pearl Woods, LLC
+// today : 2013-09-20 Binky Moon, LLC
 today
 
 // tokyo : 2013-11-13 GMO Registry, Inc.
 tokyo
 
-// tools : 2013-11-21 Pioneer North, LLC
+// tools : 2013-11-21 Binky Moon, LLC
 tools
 
-// top : 2014-03-20 Jiangsu Bangning Science & Technology Co.,Ltd.
+// top : 2014-03-20 .TOP Registry
 top
 
 // toray : 2014-12-18 Toray Industries, Inc.
@@ -9853,29 +9994,32 @@ toray
 // toshiba : 2014-04-10 TOSHIBA Corporation
 toshiba
 
-// total : 2015-08-06 Total SA
+// total : 2015-08-06 TOTAL SE
 total
 
-// tours : 2015-01-22 Sugar Station, LLC
+// tours : 2015-01-22 Binky Moon, LLC
 tours
 
-// town : 2014-03-06 Koko Moon, LLC
+// town : 2014-03-06 Binky Moon, LLC
 town
 
 // toyota : 2015-04-23 TOYOTA MOTOR CORPORATION
 toyota
 
-// toys : 2014-03-06 Pioneer Orchard, LLC
+// toys : 2014-03-06 Binky Moon, LLC
 toys
 
 // trade : 2014-01-23 Elite Registry Limited
 trade
 
-// trading : 2014-12-11 IG Group Holdings PLC
+// trading : 2014-12-11 Dog Beach, LLC
 trading
 
-// training : 2013-11-07 Wild Willow, LLC
+// training : 2013-11-07 Binky Moon, LLC
 training
+
+// travel : 2015-10-09 Dog Beach, LLC
+travel
 
 // travelchannel : 2015-07-02 Lifestyle Domain Holdings, Inc.
 travelchannel
@@ -9886,7 +10030,7 @@ travelers
 // travelersinsurance : 2015-03-26 Travelers TLD, LLC
 travelersinsurance
 
-// trust : 2014-10-16
+// trust : 2014-10-16 UNR Corp.
 trust
 
 // trv : 2015-03-26 Travelers TLD, LLC
@@ -9898,10 +10042,10 @@ tube
 // tui : 2014-07-03 TUI AG
 tui
 
-// tunes : 2015-02-26 Amazon EU S.à r.l.
+// tunes : 2015-02-26 Amazon Registry Services, Inc.
 tunes
 
-// tushu : 2014-12-18 Amazon EU S.à r.l.
+// tushu : 2014-12-18 Amazon Registry Services, Inc.
 tushu
 
 // tvs : 2015-02-19 T V SUNDRAM IYENGAR  & SONS LIMITED
@@ -9913,16 +10057,13 @@ ubank
 // ubs : 2014-12-11 UBS AG
 ubs
 
-// uconnect : 2015-07-30 FCA US LLC.
-uconnect
-
 // unicom : 2015-10-15 China United Network Communications Corporation Limited
 unicom
 
-// university : 2014-03-06 Little Station, LLC
+// university : 2014-03-06 Binky Moon, LLC
 university
 
-// uno : 2013-09-11 Dot Latin LLC
+// uno : 2013-09-11 Radix FZC
 uno
 
 // uol : 2014-05-01 UBN INTERNET LTDA.
@@ -9931,7 +10072,7 @@ uol
 // ups : 2015-06-25 UPS Market Driver, Inc.
 ups
 
-// vacations : 2013-12-05 Atomic Tigers, LLC
+// vacations : 2013-12-05 Binky Moon, LLC
 vacations
 
 // vana : 2014-12-11 Lifestyle Domain Holdings, Inc.
@@ -9943,22 +10084,22 @@ vanguard
 // vegas : 2014-01-16 Dot Vegas, Inc.
 vegas
 
-// ventures : 2013-08-27 Binky Lake, LLC
+// ventures : 2013-08-27 Binky Moon, LLC
 ventures
 
 // verisign : 2015-08-13 VeriSign, Inc.
 verisign
 
-// versicherung : 2014-03-20
+// versicherung : 2014-03-20 tldbox GmbH
 versicherung
 
-// vet : 2014-03-06
+// vet : 2014-03-06 Dog Beach, LLC
 vet
 
-// viajes : 2013-10-17 Black Madison, LLC
+// viajes : 2013-10-17 Binky Moon, LLC
 viajes
 
-// video : 2014-10-16
+// video : 2014-10-16 Dog Beach, LLC
 video
 
 // vig : 2015-05-14 VIENNA INSURANCE GROUP AG Wiener Versicherung Gruppe
@@ -9967,13 +10108,13 @@ vig
 // viking : 2015-04-02 Viking River Cruises (Bermuda) Ltd.
 viking
 
-// villas : 2013-12-05 New Sky, LLC
+// villas : 2013-12-05 Binky Moon, LLC
 villas
 
-// vin : 2015-06-18 Holly Shadow, LLC
+// vin : 2015-06-18 Binky Moon, LLC
 vin
 
-// vip : 2015-01-22 Minds + Machines Group Limited
+// vip : 2015-01-22 Registry Services, LLC
 vip
 
 // virgin : 2014-09-25 Virgin Enterprises Limited
@@ -9982,14 +10123,8 @@ virgin
 // visa : 2015-07-30 Visa Worldwide Pte. Limited
 visa
 
-// vision : 2013-12-05 Koko Station, LLC
+// vision : 2013-12-05 Binky Moon, LLC
 vision
-
-// vista : 2014-09-18 Vistaprint Limited
-vista
-
-// vistaprint : 2014-09-18 Vistaprint Limited
-vistaprint
 
 // viva : 2014-11-07 Saudi Telecom Company
 viva
@@ -10000,7 +10135,7 @@ vivo
 // vlaanderen : 2014-02-06 DNS.be vzw
 vlaanderen
 
-// vodka : 2013-12-19 Top Level Domain Holdings Limited
+// vodka : 2013-12-19 Registry Services, LLC
 vodka
 
 // volkswagen : 2015-05-14 Volkswagen Group of America Inc.
@@ -10018,7 +10153,7 @@ voting
 // voto : 2013-11-21 Monolith Registry LLC
 voto
 
-// voyage : 2013-08-27 Ruby House, LLC
+// voyage : 2013-08-27 Binky Moon, LLC
 voyage
 
 // vuelos : 2015-03-05 Travel Reservations SRL
@@ -10033,25 +10168,22 @@ walmart
 // walter : 2014-11-13 Sandvik AB
 walter
 
-// wang : 2013-10-24 Zodiac Leo Limited
+// wang : 2013-10-24 Zodiac Wang Limited
 wang
 
-// wanggou : 2014-12-18 Amazon EU S.à r.l.
+// wanggou : 2014-12-18 Amazon Registry Services, Inc.
 wanggou
 
-// warman : 2015-06-18 Weir Group IP Limited
-warman
-
-// watch : 2013-11-14 Sand Shadow, LLC
+// watch : 2013-11-14 Binky Moon, LLC
 watch
 
-// watches : 2014-12-22 Richemont DNS Inc.
+// watches : 2014-12-22 Afilias Limited
 watches
 
-// weather : 2015-01-08 The Weather Channel, LLC
+// weather : 2015-01-08 International Business Machines Corporation
 weather
 
-// weatherchannel : 2015-03-12 The Weather Channel, LLC
+// weatherchannel : 2015-03-12 International Business Machines Corporation
 weatherchannel
 
 // webcam : 2014-01-23 dot Webcam Limited
@@ -10060,13 +10192,10 @@ webcam
 // weber : 2015-06-04 Saint-Gobain Weber SA
 weber
 
-// website : 2014-04-03 DotWebsite Inc.
+// website : 2014-04-03 Radix FZC
 website
 
-// wed : 2013-10-01 Atgron, Inc.
-wed
-
-// wedding : 2014-04-24 Top Level Domain Holdings Limited
+// wedding : 2014-04-24 Registry Services, LLC
 wedding
 
 // weibo : 2015-03-05 Sina Corporation
@@ -10093,7 +10222,7 @@ win
 // windows : 2014-12-18 Microsoft Corporation
 windows
 
-// wine : 2015-06-18 June Station, LLC
+// wine : 2015-06-18 Binky Moon, LLC
 wine
 
 // winners : 2015-07-16 The TJX Companies, Inc.
@@ -10108,22 +10237,22 @@ wolterskluwer
 // woodside : 2015-07-09 Woodside Petroleum Limited
 woodside
 
-// work : 2013-12-19 Top Level Domain Holdings Limited
+// work : 2013-12-19 Registry Services, LLC
 work
 
-// works : 2013-11-14 Little Dynamite, LLC
+// works : 2013-11-14 Binky Moon, LLC
 works
 
-// world : 2014-06-12 Bitter Fields, LLC
+// world : 2014-06-12 Binky Moon, LLC
 world
 
-// wow : 2015-10-08 Amazon EU S.à r.l.
+// wow : 2015-10-08 Amazon Registry Services, Inc.
 wow
 
 // wtc : 2013-12-19 World Trade Centers Association, Inc.
 wtc
 
-// wtf : 2014-03-06 Hidden Way, LLC
+// wtf : 2014-03-06 Binky Moon, LLC
 wtf
 
 // xbox : 2014-12-18 Microsoft Corporation
@@ -10135,7 +10264,7 @@ xerox
 // xfinity : 2015-07-09 Comcast IP Holdings I, LLC
 xfinity
 
-// xihuan : 2015-01-08 QIHOO 360 TECHNOLOGY CO. LTD.
+// xihuan : 2015-01-08 Beijing Qihu Keji Co., Ltd.
 xihuan
 
 // xin : 2014-12-11 Elegant Leader Limited
@@ -10144,7 +10273,7 @@ xin
 // xn--11b4c3d : 2015-01-15 VeriSign Sarl
 कॉम
 
-// xn--1ck2e1b : 2015-02-26 Amazon EU S.à r.l.
+// xn--1ck2e1b : 2015-02-26 Amazon Registry Services, Inc.
 セール
 
 // xn--1qqw23a : 2014-01-09 Guangzhou YU Wei Information Technology Co., Ltd.
@@ -10156,11 +10285,8 @@ xin
 // xn--3bst00m : 2013-09-13 Eagle Horizon Limited
 集团
 
-// xn--3ds443g : 2013-09-08 TLD REGISTRY LIMITED
+// xn--3ds443g : 2013-09-08 TLD REGISTRY LIMITED OY
 在线
-
-// xn--3oq18vl8pn36a : 2015-07-02 Volkswagen (China) Investment Co., Ltd.
-大众汽车
 
 // xn--3pxu8k : 2015-01-15 VeriSign Sarl
 点看
@@ -10168,16 +10294,16 @@ xin
 // xn--42c2d9a : 2015-01-15 VeriSign Sarl
 คอม
 
-// xn--45q11c : 2013-11-21 Zodiac Scorpio Limited
+// xn--45q11c : 2013-11-21 Zodiac Gemini Ltd
 八卦
 
-// xn--4gbrim : 2013-10-04 Suhub Electronic Establishment
+// xn--4gbrim : 2013-10-04 Helium TLDs Ltd
 موقع
 
 // xn--55qw42g : 2013-11-08 China Organizational Name Administration Center
 公益
 
-// xn--55qx5d : 2013-11-14 Computer Network Information Center of Chinese Academy of Sciences （China Internet Network Information Center）
+// xn--55qx5d : 2013-11-14 China Internet Network Information Center (CNNIC)
 公司
 
 // xn--5su34j936bgsg : 2015-09-03 Shangri‐La International Hotel Management Limited
@@ -10219,7 +10345,7 @@ xin
 // xn--b4w605ferd : 2014-08-07 Temasek Holdings (Private) Limited
 淡马锡
 
-// xn--bck1b9a5dre4c : 2015-02-26 Amazon EU S.à r.l.
+// xn--bck1b9a5dre4c : 2015-02-26 Amazon Registry Services, Inc.
 ファッション
 
 // xn--c1avg : 2013-11-14 Public Interest Registry
@@ -10228,46 +10354,46 @@ xin
 // xn--c2br7g : 2015-01-15 VeriSign Sarl
 नेट
 
-// xn--cck2b3b : 2015-02-26 Amazon EU S.à r.l.
+// xn--cck2b3b : 2015-02-26 Amazon Registry Services, Inc.
 ストア
+
+// xn--cckwcxetd : 2019-12-19 Amazon Registry Services, Inc.
+アマゾン
 
 // xn--cg4bki : 2013-09-27 SAMSUNG SDS CO., LTD
 삼성
 
-// xn--czr694b : 2014-01-16 Dot Trademark TLD Holding Company Limited
+// xn--czr694b : 2014-01-16 Internet DotTrademark Organisation Limited
 商标
 
-// xn--czrs0t : 2013-12-19 Wild Island, LLC
+// xn--czrs0t : 2013-12-19 Binky Moon, LLC
 商店
 
-// xn--czru2d : 2013-11-21 Zodiac Capricorn Limited
+// xn--czru2d : 2013-11-21 Zodiac Aquarius Limited
 商城
 
 // xn--d1acj3b : 2013-11-20 The Foundation for Network Initiatives “The Smart Internet”
 дети
 
-// xn--eckvdtc9d : 2014-12-18 Amazon EU S.à r.l.
+// xn--eckvdtc9d : 2014-12-18 Amazon Registry Services, Inc.
 ポイント
 
-// xn--efvy88h : 2014-08-22 Xinhua News Agency Guangdong Branch 新华通讯社广东分社
+// xn--efvy88h : 2014-08-22 Guangzhou YU Wei Information Technology Co., Ltd.
 新闻
 
-// xn--estv75g : 2015-02-19 Industrial and Commercial Bank of China Limited
-工行
-
-// xn--fct429k : 2015-04-09 Amazon EU S.à r.l.
+// xn--fct429k : 2015-04-09 Amazon Registry Services, Inc.
 家電
 
 // xn--fhbei : 2015-01-15 VeriSign Sarl
 كوم
 
-// xn--fiq228c5hs : 2013-09-08 TLD REGISTRY LIMITED
+// xn--fiq228c5hs : 2013-09-08 TLD REGISTRY LIMITED OY
 中文网
 
 // xn--fiq64b : 2013-10-14 CITIC Group Corporation
 中信
 
-// xn--fjq720a : 2014-05-22 Will Bloom, LLC
+// xn--fjq720a : 2014-05-22 Binky Moon, LLC
 娱乐
 
 // xn--flw351e : 2014-07-31 Charleston Road Registry Inc.
@@ -10276,41 +10402,41 @@ xin
 // xn--fzys8d69uvgm : 2015-05-14 PCCW Enterprises Limited
 電訊盈科
 
-// xn--g2xx48c : 2015-01-30 Minds + Machines Group Limited
+// xn--g2xx48c : 2015-01-30 Nawang Heli(Xiamen) Network Service Co., LTD.
 购物
 
-// xn--gckr3f0f : 2015-02-26 Amazon EU S.à r.l.
+// xn--gckr3f0f : 2015-02-26 Amazon Registry Services, Inc.
 クラウド
 
-// xn--gk3at1e : 2015-10-08 Amazon EU S.à r.l.
+// xn--gk3at1e : 2015-10-08 Amazon Registry Services, Inc.
 通販
 
-// xn--hxt814e : 2014-05-15 Zodiac Libra Limited
+// xn--hxt814e : 2014-05-15 Zodiac Taurus Limited
 网店
 
 // xn--i1b6b1a6a2e : 2013-11-14 Public Interest Registry
 संगठन
 
-// xn--imr513n : 2014-12-11 Dot Trademark TLD Holding Company Limited
+// xn--imr513n : 2014-12-11 Internet DotTrademark Organisation Limited
 餐厅
 
-// xn--io0a7i : 2013-11-14 Computer Network Information Center of Chinese Academy of Sciences （China Internet Network Information Center）
+// xn--io0a7i : 2013-11-14 China Internet Network Information Center (CNNIC)
 网络
 
 // xn--j1aef : 2015-01-15 VeriSign Sarl
 ком
 
+// xn--jlq480n2rg : 2019-12-19 Amazon Registry Services, Inc.
+亚马逊
+
 // xn--jlq61u9w7b : 2015-01-08 Nokia Corporation
 诺基亚
 
-// xn--jvr189m : 2015-02-26 Amazon EU S.à r.l.
+// xn--jvr189m : 2015-02-26 Amazon Registry Services, Inc.
 食品
 
 // xn--kcrx77d1x4a : 2014-11-07 Koninklijke Philips N.V.
 飞利浦
-
-// xn--kpu716f : 2014-12-22 Richemont DNS Inc.
-手表
 
 // xn--kput3i : 2014-02-13 Beijing RITT-Net Technology Development Co., Ltd
 手机
@@ -10326,9 +10452,6 @@ xin
 
 // xn--mgbab2bd : 2013-10-31 CORE Association
 بازار
-
-// xn--mgbb9fbpob : 2014-12-18 GreenTech Consultancy Company W.L.L.
-موبايلي
 
 // xn--mgbca7dzdo : 2015-07-30 Abu Dhabi Systems and Information Centre
 ابوظبي
@@ -10363,11 +10486,11 @@ xin
 // xn--nyqy26a : 2014-11-07 Stable Tone Limited
 健康
 
+// xn--otu796d : 2017-08-06 Jiang Yu Liang Cai Technology Company Limited
+招聘
+
 // xn--p1acf : 2013-12-12 Rusnames Limited
 рус
-
-// xn--pbt977c : 2014-12-22 Richemont DNS Inc.
-珠宝
 
 // xn--pssy2u : 2015-01-15 VeriSign Sarl
 大拿
@@ -10381,10 +10504,10 @@ xin
 // xn--rhqv96g : 2013-09-11 Stable Tone Limited
 世界
 
-// xn--rovu88b : 2015-02-26 Amazon EU S.à r.l.
+// xn--rovu88b : 2015-02-26 Amazon Registry Services, Inc.
 書籍
 
-// xn--ses554g : 2014-01-16
+// xn--ses554g : 2014-01-16 KNET Co., Ltd.
 网址
 
 // xn--t60b56a : 2015-01-15 VeriSign Sarl
@@ -10396,7 +10519,7 @@ xin
 // xn--tiq49xqyj : 2015-10-21 Pontificium Consilium de Comunicationibus Socialibus (PCCS) (Pontifical Council for Social Communication)
 天主教
 
-// xn--unup4y : 2013-07-14 Spring Fields, LLC
+// xn--unup4y : 2013-07-14 Binky Moon, LLC
 游戏
 
 // xn--vermgensberater-ctb : 2014-06-23 Deutsche Vermögensberatung Aktiengesellschaft DVAG
@@ -10405,7 +10528,7 @@ vermögensberater
 // xn--vermgensberatung-pwb : 2014-06-23 Deutsche Vermögensberatung Aktiengesellschaft DVAG
 vermögensberatung
 
-// xn--vhquv : 2013-08-27 Dash McCook, LLC
+// xn--vhquv : 2013-08-27 Binky Moon, LLC
 企业
 
 // xn--vuq861b : 2014-10-16 Beijing Tele-info Network Technology Co., Ltd.
@@ -10423,58 +10546,52 @@ vermögensberatung
 // xn--zfr164b : 2013-11-08 China Organizational Name Administration Center
 政务
 
-// xperia : 2015-05-14 Sony Mobile Communications AB
-xperia
-
 // xyz : 2013-12-05 XYZ.COM LLC
 xyz
 
-// yachts : 2014-01-09 DERYachts, LLC
+// yachts : 2014-01-09 XYZ.COM LLC
 yachts
 
-// yahoo : 2015-04-02 Yahoo! Domain Services Inc.
+// yahoo : 2015-04-02 Oath Inc.
 yahoo
 
-// yamaxun : 2014-12-18 Amazon EU S.à r.l.
+// yamaxun : 2014-12-18 Amazon Registry Services, Inc.
 yamaxun
 
-// yandex : 2014-04-10 YANDEX, LLC
+// yandex : 2014-04-10 Yandex Europe B.V.
 yandex
 
 // yodobashi : 2014-11-20 YODOBASHI CAMERA CO.,LTD.
 yodobashi
 
-// yoga : 2014-05-29 Top Level Domain Holdings Limited
+// yoga : 2014-05-29 Registry Services, LLC
 yoga
 
 // yokohama : 2013-12-12 GMO Registry, Inc.
 yokohama
 
-// you : 2015-04-09 Amazon EU S.à r.l.
+// you : 2015-04-09 Amazon Registry Services, Inc.
 you
 
 // youtube : 2014-05-01 Charleston Road Registry Inc.
 youtube
 
-// yun : 2015-01-08 QIHOO 360 TECHNOLOGY CO. LTD.
+// yun : 2015-01-08 Beijing Qihu Keji Co., Ltd.
 yun
 
-// zappos : 2015-06-25 Amazon EU S.à r.l.
+// zappos : 2015-06-25 Amazon Registry Services, Inc.
 zappos
 
 // zara : 2014-11-07 Industria de Diseño Textil, S.A. (INDITEX, S.A.)
 zara
 
-// zero : 2014-12-18 Amazon EU S.à r.l.
+// zero : 2014-12-18 Amazon Registry Services, Inc.
 zero
 
 // zip : 2014-05-08 Charleston Road Registry Inc.
 zip
 
-// zippo : 2015-07-02 Zadco Company
-zippo
-
-// zone : 2013-11-14 Outer Falls, LLC
+// zone : 2013-11-14 Binky Moon, LLC
 zone
 
 // zuerich : 2014-11-07 Kanton Zürich (Canton of Zurich)
@@ -10485,18 +10602,66 @@ zuerich
 // ===BEGIN PRIVATE DOMAINS===
 // (Note: these are in alphabetical order by company name)
 
+// 1GB LLC : https://www.1gb.ua/
+// Submitted by 1GB LLC <noc@1gb.com.ua>
+cc.ua
+inf.ua
+ltd.ua
+
+// 611coin : https://611project.org/
+611.to
+
+// Aaron Marais' Gitlab pages: https://lab.aaronleem.co.za
+// Submitted by Aaron Marais <its_me@aaronleem.co.za>
+graphox.us
+
+// accesso Technology Group, plc. : https://accesso.com/
+// Submitted by accesso Team <accessoecommerce@accesso.com>
+*.devcdnaccesso.com
+
+// Adobe : https://www.adobe.com/
+// Submitted by Ian Boston <boston@adobe.com> and Lars Trieloff <trieloff@adobe.com>
+adobeaemcloud.com
+*.dev.adobeaemcloud.com
+hlx.live
+adobeaemcloud.net
+hlx.page
+hlx3.page
+
 // Agnat sp. z o.o. : https://domena.pl
 // Submitted by Przemyslaw Plewa <it-admin@domena.pl>
 beep.pl
+
+// Airkit : https://www.airkit.com/
+// Submitted by Grant Cooksey <security@airkit.com>
+airkitapps.com
+airkitapps-au.com
+airkitapps.eu
+
+// Aiven: https://aiven.io/
+// Submitted by Etienne Stalmans <security@aiven.io>
+aivencloud.com
+
+// alboto.ca : http://alboto.ca
+// Submitted by Anton Avramov <avramov@alboto.ca>
+barsy.ca
 
 // Alces Software Ltd : http://alces-software.com
 // Submitted by Mark J. Titorenko <mark.titorenko@alces-software.com>
 *.compute.estate
 *.alces.network
 
+// all-inkl.com : https://all-inkl.com
+// Submitted by Werner Kaltofen <wk@all-inkl.com>
+kasserver.com
+
+// Altervista: https://www.altervista.org
+// Submitted by Carlo Cannas <tech_staff@altervista.it>
+altervista.org
+
 // alwaysdata : https://www.alwaysdata.com
 // Submitted by Cyril <admin@alwaysdata.com>
-*.alwaysdata.net
+alwaysdata.net
 
 // Amazon CloudFront : https://aws.amazon.com/cloudfront/
 // Submitted by Donavan Miller <donavanm@amazon.com>
@@ -10511,13 +10676,35 @@ us-east-1.amazonaws.com
 
 // Amazon Elastic Beanstalk : https://aws.amazon.com/elasticbeanstalk/
 // Submitted by Luke Wells <psl-maintainers@amazon.com>
-elasticbeanstalk.cn-north-1.amazonaws.com.cn
-*.elasticbeanstalk.com
+cn-north-1.eb.amazonaws.com.cn
+cn-northwest-1.eb.amazonaws.com.cn
+elasticbeanstalk.com
+ap-northeast-1.elasticbeanstalk.com
+ap-northeast-2.elasticbeanstalk.com
+ap-northeast-3.elasticbeanstalk.com
+ap-south-1.elasticbeanstalk.com
+ap-southeast-1.elasticbeanstalk.com
+ap-southeast-2.elasticbeanstalk.com
+ca-central-1.elasticbeanstalk.com
+eu-central-1.elasticbeanstalk.com
+eu-west-1.elasticbeanstalk.com
+eu-west-2.elasticbeanstalk.com
+eu-west-3.elasticbeanstalk.com
+sa-east-1.elasticbeanstalk.com
+us-east-1.elasticbeanstalk.com
+us-east-2.elasticbeanstalk.com
+us-gov-west-1.elasticbeanstalk.com
+us-west-1.elasticbeanstalk.com
+us-west-2.elasticbeanstalk.com
 
 // Amazon Elastic Load Balancing : https://aws.amazon.com/elasticloadbalancing/
 // Submitted by Luke Wells <psl-maintainers@amazon.com>
 *.elb.amazonaws.com
 *.elb.amazonaws.com.cn
+
+// Amazon Global Accelerator : https://aws.amazon.com/global-accelerator/
+// Submitted by Daniel Massaguer <psl-maintainers@amazon.com>
+awsglobalaccelerator.com
 
 // Amazon S3 : https://aws.amazon.com/s3/
 // Submitted by Luke Wells <psl-maintainers@amazon.com>
@@ -10531,6 +10718,7 @@ s3-ca-central-1.amazonaws.com
 s3-eu-central-1.amazonaws.com
 s3-eu-west-1.amazonaws.com
 s3-eu-west-2.amazonaws.com
+s3-eu-west-3.amazonaws.com
 s3-external-1.amazonaws.com
 s3-fips-us-gov-west-1.amazonaws.com
 s3-sa-east-1.amazonaws.com
@@ -10544,6 +10732,7 @@ s3.cn-north-1.amazonaws.com.cn
 s3.ca-central-1.amazonaws.com
 s3.eu-central-1.amazonaws.com
 s3.eu-west-2.amazonaws.com
+s3.eu-west-3.amazonaws.com
 s3.us-east-2.amazonaws.com
 s3.dualstack.ap-northeast-1.amazonaws.com
 s3.dualstack.ap-northeast-2.amazonaws.com
@@ -10554,6 +10743,7 @@ s3.dualstack.ca-central-1.amazonaws.com
 s3.dualstack.eu-central-1.amazonaws.com
 s3.dualstack.eu-west-1.amazonaws.com
 s3.dualstack.eu-west-2.amazonaws.com
+s3.dualstack.eu-west-3.amazonaws.com
 s3.dualstack.sa-east-1.amazonaws.com
 s3.dualstack.us-east-1.amazonaws.com
 s3.dualstack.us-east-2.amazonaws.com
@@ -10570,6 +10760,7 @@ s3-website.ap-south-1.amazonaws.com
 s3-website.ca-central-1.amazonaws.com
 s3-website.eu-central-1.amazonaws.com
 s3-website.eu-west-2.amazonaws.com
+s3-website.eu-west-3.amazonaws.com
 s3-website.us-east-2.amazonaws.com
 
 // Amune : https://amune.org/
@@ -10577,9 +10768,32 @@ s3-website.us-east-2.amazonaws.com
 t3l3p0rt.net
 tele.amune.org
 
+// Apigee : https://apigee.com/
+// Submitted by Apigee Security Team <security@apigee.com>
+apigee.io
+
+// Apphud : https://apphud.com
+// Submitted by Alexander Selivanov <alex@apphud.com>
+siiites.com
+
+// Appspace : https://www.appspace.com
+// Submitted by Appspace Security Team <security@appspace.com>
+appspacehosted.com
+appspaceusercontent.com
+
+// Appudo UG (haftungsbeschränkt) : https://www.appudo.com
+// Submitted by Alexander Hochbaum <admin@appudo.com>
+appudo.net
+
 // Aptible : https://www.aptible.com/
 // Submitted by Thomas Orozco <thomas@aptible.com>
 on-aptible.com
+
+// ASEINet : https://www.aseinet.com/
+// Submitted by Asei SEKIGUCHI <mail@aseinet.com>
+user.aseinet.ne.jp
+gv.vc
+d.gv.vc
 
 // Asociación Amigos de la Informática "Euskalamiga" : http://encounter.eus/
 // Submitted by Hector Martin <marcan@euskalencounter.org>
@@ -10596,18 +10810,70 @@ sweetpepper.org
 // Submitted by Vincent Tseng <vincenttseng@asustor.com>
 myasustor.com
 
+// Atlassian : https://atlassian.com
+// Submitted by Sam Smyth <devloop@atlassian.com>
+cdn.prod.atlassian-dev.net
+
+// Authentick UG (haftungsbeschränkt) : https://authentick.net
+// Submitted by Lukas Reschke <lukas@authentick.net>
+translated.page
+
 // AVM : https://avm.de
 // Submitted by Andreas Weise <a.weise@avm.de>
 myfritz.net
+
+// AVStack Pte. Ltd. : https://avstack.io
+// Submitted by Jasper Hugo <jasper@avstack.io>
+onavstack.net
 
 // AW AdvisorWebsites.com Software Inc : https://advisorwebsites.com
 // Submitted by James Kennedy <domains@advisorwebsites.com>
 *.awdev.ca
 *.advisor.ws
 
+// AZ.pl sp. z.o.o: https://az.pl
+// Submitted by Krzysztof Wolski <krzysztof.wolski@home.eu>
+ecommerce-shop.pl
+
+// b-data GmbH : https://www.b-data.io
+// Submitted by Olivier Benz <olivier.benz@b-data.ch>
+b-data.io
+
 // backplane : https://www.backplane.io
 // Submitted by Anthony Voutas <anthony@backplane.io>
 backplaneapp.io
+
+// Balena : https://www.balena.io
+// Submitted by Petros Angelatos <petrosagg@balena.io>
+balena-devices.com
+
+// University of Banja Luka : https://unibl.org
+// Domains for Republic of Srpska administrative entity.
+// Submitted by Marko Ivanovic <kormang@hotmail.rs>
+rs.ba
+
+// Banzai Cloud
+// Submitted by Janos Matyas <info@banzaicloud.com>
+*.banzai.cloud
+app.banzaicloud.io
+*.backyards.banzaicloud.io
+
+// BASE, Inc. : https://binc.jp
+// Submitted by Yuya NAGASAWA <public-suffix-list@binc.jp>
+base.ec
+official.ec
+buyshop.jp
+fashionstore.jp
+handcrafted.jp
+kawaiishop.jp
+supersale.jp
+theshop.jp
+shopselect.net
+base.shop
+
+// Beget Ltd
+// Submitted by Lev Nekrasov <lnekrasov@beget.com>
+*.beget.app
 
 // BetaInABox
 // Submitted by Adrian <adrian@betainabox.com>
@@ -10616,6 +10882,30 @@ betainabox.com
 // BinaryLane : http://www.binarylane.com
 // Submitted by Nathan O'Sullivan <nathan@mammoth.com.au>
 bnr.la
+
+// Bitbucket : http://bitbucket.org
+// Submitted by Andy Ortlieb <aortlieb@atlassian.com>
+bitbucket.io
+
+// Blackbaud, Inc. : https://www.blackbaud.com
+// Submitted by Paul Crowder <paul.crowder@blackbaud.com>
+blackbaudcdn.net
+
+// Blatech : http://www.blatech.net
+// Submitted by Luke Bratch <luke@bratch.co.uk>
+of.je
+
+// Blue Bite, LLC : https://bluebite.com
+// Submitted by Joshua Weiss <admin.engineering@bluebite.com>
+bluebite.io
+
+// Boomla : https://boomla.com
+// Submitted by Tibor Halter <thalter@boomla.com>
+boomla.net
+
+// Boutir : https://www.boutir.com
+// Submitted by Eric Ng Ka Ka <ngkaka@boutir.com>
+boutir.com
 
 // Boxfuse : https://boxfuse.com
 // Submitted by Axel Fontaine <axel@boxfuse.com>
@@ -10630,44 +10920,67 @@ square7.de
 bplaced.net
 square7.net
 
+// Brendly : https://brendly.rs
+// Submitted by Dusan Radovanovic <dusan.radovanovic@brendly.rs>
+shop.brendly.rs
+
 // BrowserSafetyMark
 // Submitted by Dave Tharp <browsersafetymark.io@quicinc.com>
 browsersafetymark.io
+
+// Bytemark Hosting : https://www.bytemark.co.uk
+// Submitted by Paul Cammish <paul.cammish@bytemark.co.uk>
+uk0.bigv.io
+dh.bytemark.co.uk
+vm.bytemark.co.uk
+
+// Caf.js Labs LLC : https://www.cafjs.com
+// Submitted by Antonio Lain <antlai@cafjs.com>
+cafjs.com
 
 // callidomus : https://www.callidomus.com/
 // Submitted by Marcus Popp <admin@callidomus.com>
 mycd.eu
 
+// Carrd : https://carrd.co
+// Submitted by AJ <aj@carrd.co>
+drr.ac
+uwu.ai
+carrd.co
+crd.co
+ju.mp
+
 // CentralNic : http://www.centralnic.com/names/domains
 // Submitted by registry <gavin.brown@centralnic.com>
 ae.org
-ar.com
 br.com
 cn.com
 com.de
 com.se
 de.com
 eu.com
-gb.com
 gb.net
-hu.com
 hu.net
 jp.net
 jpn.com
-kr.com
 mex.com
-no.com
-qc.com
 ru.com
 sa.com
-se.com
 se.net
 uk.com
 uk.net
 us.com
-uy.com
 za.bz
 za.com
+
+// No longer operated by CentralNic, these entries should be adopted and/or removed by current operators
+// Submitted by Gavin Brown <gavin.brown@centralnic.com>
+ar.com
+hu.com
+kr.com
+no.com
+qc.com
+uy.com
 
 // Africa.com Web Solutions Ltd : https://registry.africa.com
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
@@ -10680,6 +10993,7 @@ gr.com
 // Radix FZC : http://domains.in.net
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
 in.net
+web.in
 
 // US REGISTRY LLC : http://us.org
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
@@ -10689,6 +11003,16 @@ us.org
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
 co.com
 
+// Roar Domains LLC : https://roar.basketball/
+// Submitted by Gavin Brown <gavin.brown@centralnic.com>
+aus.basketball
+nz.basketball
+
+// BRS Media : https://brsmedia.com/
+// Submitted by Gavin Brown <gavin.brown@centralnic.com>
+radio.am
+radio.fm
+
 // c.la : http://www.c.la/
 c.la
 
@@ -10696,25 +11020,71 @@ c.la
 // Submitted by B. Blechschmidt <hostmaster@certmgr.org>
 certmgr.org
 
-// Citrix : https://citrix.com
-// Submitted by Alex Stoddard <alex.stoddard@citrix.com>
-xenapponazure.com
+// Cityhost LLC  : https://cityhost.ua
+// Submitted by Maksym Rivtin <support@cityhost.net.ua>
+cx.ua
 
-// ClearVox : http://www.clearvox.nl/
-// Submitted by Leon Rowland <leon@clearvox.nl>
-virtueeldomein.nl
+// Civilized Discourse Construction Kit, Inc. : https://www.discourse.org/
+// Submitted by Rishabh Nambiar & Michael Brown <team@discourse.org>
+discourse.group
+discourse.team
+
+// Clever Cloud : https://www.clever-cloud.com/
+// Submitted by Quentin Adam <noc@clever-cloud.com>
+cleverapps.io
+
+// Clerk : https://www.clerk.dev
+// Submitted by Colin Sidoti <systems@clerk.dev>
+clerk.app
+clerkstage.app
+*.lcl.dev
+*.lclstage.dev
+*.stg.dev
+*.stgstage.dev
+
+// ClickRising : https://clickrising.com/
+// Submitted by Umut Gumeli <infrastructure-publicsuffixlist@clickrising.com>
+clickrising.net
 
 // Cloud66 : https://www.cloud66.com/
 // Submitted by Khash Sajadi <khash@cloud66.com>
 c66.me
+cloud66.ws
+cloud66.zone
+
+// CloudAccess.net : https://www.cloudaccess.net/
+// Submitted by Pawel Panek <noc@cloudaccess.net>
+jdevcloud.com
+wpdevcloud.com
+cloudaccess.host
+freesite.host
+cloudaccess.net
 
 // cloudControl : https://www.cloudcontrol.com/
 // Submitted by Tobias Wilken <tw@cloudcontrol.com>
 cloudcontrolled.com
 cloudcontrolapp.com
 
+// Cloudera, Inc. : https://www.cloudera.com/
+// Submitted by Kedarnath Waikar <security@cloudera.com>
+*.cloudera.site
+
+// Cloudflare, Inc. : https://www.cloudflare.com/
+// Submitted by Cloudflare Team <publicsuffixlist@cloudflare.com>
+pages.dev
+trycloudflare.com
+workers.dev
+
+// Clovyr : https://clovyr.io
+// Submitted by Patrick Nielsen <patrick@clovyr.io>
+wnext.app
+
 // co.ca : http://registry.co.ca/
 co.ca
+
+// Co & Co : https://co-co.nl/
+// Submitted by Govert Versluis <govert@co-co.nl>
+*.otap.co
 
 // i-registry s.r.o. : http://www.i-registry.cz/
 // Submitted by Martin Semrad <semrad@i-registry.cz>
@@ -10742,9 +11112,31 @@ cloudns.pro
 cloudns.pw
 cloudns.us
 
+// CNPY : https://cnpy.gdn
+// Submitted by Angelo Gladding <angelo@lahacker.net>
+cnpy.gdn
+
+// Codeberg e. V. : https://codeberg.org
+// Submitted by Moritz Marquardt <git@momar.de>
+codeberg.page
+
 // CoDNS B.V.
 co.nl
 co.no
+
+// Combell.com : https://www.combell.com
+// Submitted by Thomas Wouters <thomas.wouters@combellgroup.com>
+webhosting.be
+hosting-cluster.nl
+
+// Coordination Center for TLD RU and XN--P1AI : https://cctld.ru/en/domains/domens_ru/reserved/
+// Submitted by George Georgievsky <gug@cctld.ru>
+ac.ru
+edu.ru
+gov.ru
+int.ru
+mil.ru
+test.ru
 
 // COSIMO GmbH : http://www.cosimo.de
 // Submitted by Rene Marticke <rmarticke@cosimo.de>
@@ -10770,15 +11162,42 @@ realm.cz
 // Submitted by Jonathan Rudenberg <jonathan@cupcake.io>
 cupcake.is
 
+// Curv UG : https://curv-labs.de/
+// Submitted by Marvin Wiesner <Marvin@curv-labs.de>
+curv.dev
+
+// Customer OCI - Oracle Dyn https://cloud.oracle.com/home https://dyn.com/dns/
+// Submitted by Gregory Drake <support@dyn.com>
+// Note: This is intended to also include customer-oci.com due to wildcards implicitly including the current label
+*.customer-oci.com
+*.oci.customer-oci.com
+*.ocp.customer-oci.com
+*.ocs.customer-oci.com
+
 // cyon GmbH : https://www.cyon.ch/
 // Submitted by Dominic Luechinger <dol@cyon.ch>
 cyon.link
 cyon.site
 
+// Danger Science Group: https://dangerscience.com/
+// Submitted by Skylar MacDonald <skylar@dangerscience.com>
+fnwk.site
+folionetwork.site
+platform0.app
+
 // Daplie, Inc : https://daplie.com
 // Submitted by AJ ONeal <aj@daplie.com>
 daplie.me
 localhost.daplie.me
+
+// Datto, Inc. : https://www.datto.com/
+// Submitted by Philipp Heckel <ph@datto.com>
+dattolocal.com
+dattorelay.com
+dattoweb.com
+mydatto.com
+dattolocal.net
+mydatto.net
 
 // Dansk.net : http://www.dansk.net/
 // Submitted by Anani Voule <digital@digital.co.dk>
@@ -10788,13 +11207,80 @@ firm.dk
 reg.dk
 store.dk
 
+// dappnode.io : https://dappnode.io/
+// Submitted by Abel Boldu / DAppNode Team <community@dappnode.io>
+dyndns.dappnode.io
+
+// dapps.earth : https://dapps.earth/
+// Submitted by Daniil Burdakov <icqkill@gmail.com>
+*.dapps.earth
+*.bzz.dapps.earth
+
+// Dark, Inc. : https://darklang.com
+// Submitted by Paul Biggar <ops@darklang.com>
+builtwithdark.com
+
+// DataDetect, LLC. : https://datadetect.com
+// Submitted by Andrew Banchich <abanchich@sceven.com>
+demo.datadetect.com
+instance.datadetect.com
+
+// Datawire, Inc : https://www.datawire.io
+// Submitted by Richard Li <secalert@datawire.io>
+edgestack.me
+
+// DDNS5 : https://ddns5.com
+// Submitted by Cameron Elliott <cameron@cameronelliott.com>
+ddns5.com
+
+// Debian : https://www.debian.org/
+// Submitted by Peter Palfrader / Debian Sysadmin Team <dsa-publicsuffixlist@debian.org>
+debian.net
+
+// Deno Land Inc : https://deno.com/
+// Submitted by Luca Casonato <hostmaster@deno.com>
+deno.dev
+deno-staging.dev
+
 // deSEC : https://desec.io/
 // Submitted by Peter Thomassen <peter@desec.io>
 dedyn.io
 
+// Deta: https://www.deta.sh/
+// Submitted by Aavash Shrestha <aavash@deta.sh>
+deta.app
+deta.dev
+
+// Diher Solutions : https://diher.solutions
+// Submitted by Didi Hermawan <mail@diher.solutions>
+*.rss.my.id
+*.diher.solutions
+
+// Discord Inc : https://discord.com
+// Submitted by Sahn Lam <slam@discordapp.com>
+discordsays.com
+discordsez.com
+
+// DNS Africa Ltd https://dns.business
+// Submitted by Calvin Browne <calvin@dns.business>
+jozi.biz
+
 // DNShome : https://www.dnshome.de/
 // Submitted by Norbert Auler <mail@dnshome.de>
 dnshome.de
+
+// DotArai : https://www.dotarai.com/
+// Submitted by Atsadawat Netcharadsang <atsadawat@dotarai.co.th>
+online.th
+shop.th
+
+// DrayTek Corp. : https://www.draytek.com/
+// Submitted by Paul Fang <mis@draytek.com>
+drayddns.com
+
+// DreamCommerce : https://shoper.pl/
+// Submitted by Konrad Kotarba <konrad.kotarba@dreamcommerce.com>
+shoparena.pl
 
 // DreamHost : http://www.dreamhost.com/
 // Submitted by Andrew Farmer <andrew.farmer@dreamhost.com>
@@ -10812,6 +11298,13 @@ drud.us
 // DuckDNS : http://www.duckdns.org/
 // Submitted by Richard Harper <richard@duckdns.org>
 duckdns.org
+
+// Bip : https://bip.sh
+// Submitted by Joel Kennedy <joel@bip.sh>
+bip.sh
+
+// bitbridge.net : Submitted by Craig Welch, abeliidev@gmail.com
+bitbridge.net
 
 // dy.fi : http://dy.fi/
 // Submitted by Heikki Hannikainen <hessu@hes.iki.fi>
@@ -11111,6 +11604,43 @@ dyn.home-webserver.de
 myhome-server.de
 ddnss.org
 
+// Definima : http://www.definima.com/
+// Submitted by Maxence Bitterli <maxence@definima.com>
+definima.net
+definima.io
+
+// DigitalOcean App Platform : https://www.digitalocean.com/products/app-platform/
+// Submitted by Braxton Huggins <psl-maintainers@digitalocean.com>
+ondigitalocean.app
+
+// DigitalOcean Spaces : https://www.digitalocean.com/products/spaces/
+// Submitted by Robin H. Johnson <psl-maintainers@digitalocean.com>
+*.digitaloceanspaces.com
+
+// dnstrace.pro : https://dnstrace.pro/
+// Submitted by Chris Partridge <chris@partridge.tech>
+bci.dnstrace.pro
+
+// Dynu.com : https://www.dynu.com/
+// Submitted by Sue Ye <sue@dynu.com>
+ddnsfree.com
+ddnsgeek.com
+giize.com
+gleeze.com
+kozow.com
+loseyourip.com
+ooguy.com
+theworkpc.com
+casacam.net
+dynu.net
+accesscam.org
+camdvr.org
+freeddns.org
+mywire.org
+webredirect.org
+myddns.rocks
+blogsite.xyz
+
 // dynv6 : https://dynv6.com
 // Submitted by Dominik Menke <dom@digineo.de>
 dynv6.net
@@ -11119,10 +11649,38 @@ dynv6.net
 // Submitted by Vladimir Dudr <info@e4you.cz>
 e4.cz
 
-// Enonic : http://enonic.com/
-// Submitted by Erik Kaareng-Sunde <esu@enonic.com>
-enonic.io
-customer.enonic.io
+// eero : https://eero.com/
+// Submitted by Yue Kang <eero-dynamic-dns@amazon.com>
+eero.online
+eero-stage.online
+
+// Elementor : Elementor Ltd.
+// Submitted by Anton Barkan <antonb@elementor.com>
+elementor.cloud
+elementor.cool
+
+// En root‽ : https://en-root.org
+// Submitted by Emmanuel Raviart <emmanuel@raviart.com>
+en-root.fr
+
+// Enalean SAS: https://www.enalean.com
+// Submitted by Thomas Cottier <thomas.cottier@enalean.com>
+mytuleap.com
+tuleap-partners.com
+
+// Encoretivity AB: https://encore.dev
+// Submitted by André Eriksson <andre@encore.dev>
+encr.app
+encoreapi.com
+
+// ECG Robotics, Inc: https://ecgrobotics.org
+// Submitted by <frc1533@ecgrobotics.org>
+onred.one
+staging.onred.one
+
+// encoway GmbH : https://www.encoway.de
+// Submitted by Marcel Daus <cloudops@encoway.de>
+eu.encoway.cloud
 
 // EU.org https://eu.org/
 // Submitted by Pierre Beyssac <hostmaster@eu.org>
@@ -11183,14 +11741,20 @@ tr.eu.org
 uk.eu.org
 us.eu.org
 
+// Eurobyte : https://eurobyte.ru
+// Submitted by Evgeniy Subbotin <e.subbotin@eurobyte.ru>
+eurodir.ru
+
 // Evennode : http://www.evennode.com/
 // Submitted by Michal Kralik <support@evennode.com>
 eu-1.evennode.com
 eu-2.evennode.com
 eu-3.evennode.com
+eu-4.evennode.com
 us-1.evennode.com
 us-2.evennode.com
 us-3.evennode.com
+us-4.evennode.com
 
 // eDirect Corp. : https://hosting.url.com.tw/
 // Submitted by C.S. chang <cschang@corp.url.com.tw>
@@ -11199,6 +11763,10 @@ twmail.net
 twmail.org
 mymailer.com.tw
 url.tw
+
+// Fabrica Technologies, Inc. : https://www.fabrica.dev/
+// Submitted by Eric Jiang <eric@fabrica.dev>
+onfabrica.com
 
 // Facebook, Inc.
 // Submitted by Peter Ruibal <public-suffix@fb.com>
@@ -11280,8 +11848,15 @@ vladikavkaz.su
 vladimir.su
 vologda.su
 
+// Fancy Bits, LLC : http://getchannels.com
+// Submitted by Aman Gupta <aman@getchannels.com>
+channelsdvr.net
+u.channelsdvr.net
+
 // Fastly Inc. : http://www.fastly.com/
 // Submitted by Fastly Security <security@fastly.com>
+edgecompute.app
+fastly-terrarium.com
 fastlylb.net
 map.fastlylb.net
 freetls.fastly.net
@@ -11292,23 +11867,94 @@ a.ssl.fastly.net
 b.ssl.fastly.net
 global.ssl.fastly.net
 
-// Featherhead : https://featherhead.xyz/
-// Submitted by Simon Menke <simon@featherhead.xyz>
-fhapp.xyz
+// FASTVPS EESTI OU : https://fastvps.ru/
+// Submitted by Likhachev Vasiliy <lihachev@fastvps.ru>
+fastvps-server.com
+fastvps.host
+myfast.host
+fastvps.site
+myfast.space
 
 // Fedora : https://fedoraproject.org/
 // submitted by Patrick Uiterwijk <puiterwijk@fedoraproject.org>
 fedorainfracloud.org
 fedorapeople.org
 cloud.fedoraproject.org
+app.os.fedoraproject.org
+app.os.stg.fedoraproject.org
+
+// FearWorks Media Ltd. : https://fearworksmedia.co.uk
+// submitted by Keith Fairley <domains@fearworksmedia.co.uk>
+conn.uk
+copro.uk
+hosp.uk
+
+// Fermax : https://fermax.com/
+// submitted by Koen Van Isterdael <k.vanisterdael@fermax.be>
+mydobiss.com
+
+// FH Muenster : https://www.fh-muenster.de
+// Submitted by Robin Naundorf <r.naundorf@fh-muenster.de>
+fh-muenster.io
+
+// Filegear Inc. : https://www.filegear.com
+// Submitted by Jason Zhu <jason@owtware.com>
+filegear.me
+filegear-au.me
+filegear-de.me
+filegear-gb.me
+filegear-ie.me
+filegear-jp.me
+filegear-sg.me
 
 // Firebase, Inc.
 // Submitted by Chris Raynor <chris@firebase.com>
 firebaseapp.com
 
+// Firewebkit : https://www.firewebkit.com
+// Submitted by Majid Qureshi <mqureshi@amrayn.com>
+fireweb.app
+
+// FLAP : https://www.flap.cloud
+// Submitted by Louis Chemineau <louis@chmn.me>
+flap.id
+
+// FlashDrive : https://flashdrive.io
+// Submitted by Eric Chan <support@flashdrive.io>
+onflashdrive.app
+fldrv.com
+
+// fly.io: https://fly.io
+// Submitted by Kurt Mackey <kurt@fly.io>
+fly.dev
+edgeapp.net
+shw.io
+
 // Flynn : https://flynn.io
 // Submitted by Jonathan Rudenberg <jonathan@flynn.io>
-flynnhub.com
+flynnhosting.net
+
+// Forgerock : https://www.forgerock.com
+// Submitted by Roderick Parr <roderick.parr@forgerock.com>
+forgeblocks.com
+id.forgerock.io
+
+// Framer : https://www.framer.com
+// Submitted by Koen Rouwhorst <koenrh@framer.com>
+framer.app
+framercanvas.com
+
+// Frusky MEDIA&PR : https://www.frusky.de
+// Submitted by Victor Pupynin <hallo@frusky.de>
+*.frusky.de
+
+// RavPage : https://www.ravpage.co.il
+// Submitted by Roni Horowitz <roni@responder.co.il>
+ravpage.co.il
+
+// Frederik Braun https://frederik-braun.com
+// Submitted by Frederik Braun <fb@frederik-braun.com>
+0e.vc
 
 // Freebox : http://www.freebox.fr
 // Submitted by Romain Fliedel <rfliedel@freebox.fr>
@@ -11319,35 +11965,210 @@ fbxos.fr
 freebox-os.fr
 freeboxos.fr
 
-// Fusion Intranet : https://www.fusion-intranet.com
-// Submitted by Matthias Burtscher <matthias.burtscher@fusonic.net>
-myfusion.cloud
+// freedesktop.org : https://www.freedesktop.org
+// Submitted by Daniel Stone <daniel@fooishbar.org>
+freedesktop.org
+
+// freemyip.com : https://freemyip.com
+// Submitted by Cadence <contact@freemyip.com>
+freemyip.com
+
+// FunkFeuer - Verein zur Förderung freier Netze : https://www.funkfeuer.at
+// Submitted by Daniel A. Maierhofer <vorstand@funkfeuer.at>
+wien.funkfeuer.at
 
 // Futureweb OG : http://www.futureweb.at
 // Submitted by Andreas Schnederle-Wagner <schnederle@futureweb.at>
+*.futurecms.at
+*.ex.futurecms.at
+*.in.futurecms.at
 futurehosting.at
 futuremailing.at
 *.ex.ortsinfo.at
 *.kunden.ortsinfo.at
 *.statics.cloud
 
-// GDS : https://www.gov.uk/service-manual/operations/operating-servicegovuk-subdomains
-// Submitted by David Illsley <david.illsley@digital.cabinet-office.gov.uk>
+// GDS : https://www.gov.uk/service-manual/technology/managing-domain-names
+// Submitted by Stephen Ford <hostmaster@digital.cabinet-office.gov.uk>
+independent-commission.uk
+independent-inquest.uk
+independent-inquiry.uk
+independent-panel.uk
+independent-review.uk
+public-inquiry.uk
+royal-commission.uk
+campaign.gov.uk
 service.gov.uk
+
+// CDDO : https://www.gov.uk/guidance/get-an-api-domain-on-govuk
+// Submitted by Jamie Tanna <jamie.tanna@digital.cabinet-office.gov.uk>
+api.gov.uk
+
+// Gehirn Inc. : https://www.gehirn.co.jp/
+// Submitted by Kohei YOSHIDA <tech@gehirn.co.jp>
+gehirn.ne.jp
+usercontent.jp
+
+// Gentlent, Inc. : https://www.gentlent.com
+// Submitted by Tom Klein <tom@gentlent.com>
+gentapps.com
+gentlentapis.com
+lab.ms
+cdn-edges.net
+
+// Ghost Foundation : https://ghost.org
+// Submitted by Matt Hanley <security@ghost.org>
+ghost.io
+
+// GignoSystemJapan: http://gsj.bz
+// Submitted by GignoSystemJapan <kakutou-ec@gsj.bz>
+gsj.bz
 
 // GitHub, Inc.
 // Submitted by Patrick Toomey <security@github.com>
-github.io
 githubusercontent.com
-githubcloud.com
-*.api.githubcloud.com
-*.ext.githubcloud.com
-gist.githubcloud.com
-*.githubcloudusercontent.com
+githubpreview.dev
+github.io
 
 // GitLab, Inc.
 // Submitted by Alex Hanselka <alex@gitlab.com>
 gitlab.io
+
+// Gitplac.si - https://gitplac.si
+// Submitted by Aljaž Starc <me@aljaxus.eu>
+gitapp.si
+gitpage.si
+
+// Glitch, Inc : https://glitch.com
+// Submitted by Mads Hartmann <mads@glitch.com>
+glitch.me
+
+// Global NOG Alliance : https://nogalliance.org/
+// Submitted by Sander Steffann <sander@nogalliance.org>
+nog.community
+
+// Globe Hosting SRL : https://www.globehosting.com/
+// Submitted by Gavin Brown <gavin.brown@centralnic.com>
+co.ro
+shop.ro
+
+// GMO Pepabo, Inc. : https://pepabo.com/
+// Submitted by Hosting Div <admin@pepabo.com>
+lolipop.io
+angry.jp
+babyblue.jp
+babymilk.jp
+backdrop.jp
+bambina.jp
+bitter.jp
+blush.jp
+boo.jp
+boy.jp
+boyfriend.jp
+but.jp
+candypop.jp
+capoo.jp
+catfood.jp
+cheap.jp
+chicappa.jp
+chillout.jp
+chips.jp
+chowder.jp
+chu.jp
+ciao.jp
+cocotte.jp
+coolblog.jp
+cranky.jp
+cutegirl.jp
+daa.jp
+deca.jp
+deci.jp
+digick.jp
+egoism.jp
+fakefur.jp
+fem.jp
+flier.jp
+floppy.jp
+fool.jp
+frenchkiss.jp
+girlfriend.jp
+girly.jp
+gloomy.jp
+gonna.jp
+greater.jp
+hacca.jp
+heavy.jp
+her.jp
+hiho.jp
+hippy.jp
+holy.jp
+hungry.jp
+icurus.jp
+itigo.jp
+jellybean.jp
+kikirara.jp
+kill.jp
+kilo.jp
+kuron.jp
+littlestar.jp
+lolitapunk.jp
+lomo.jp
+lovepop.jp
+lovesick.jp
+main.jp
+mods.jp
+mond.jp
+mongolian.jp
+moo.jp
+namaste.jp
+nikita.jp
+nobushi.jp
+noor.jp
+oops.jp
+parallel.jp
+parasite.jp
+pecori.jp
+peewee.jp
+penne.jp
+pepper.jp
+perma.jp
+pigboat.jp
+pinoko.jp
+punyu.jp
+pupu.jp
+pussycat.jp
+pya.jp
+raindrop.jp
+readymade.jp
+sadist.jp
+schoolbus.jp
+secret.jp
+staba.jp
+stripper.jp
+sub.jp
+sunnyday.jp
+thick.jp
+tonkotsu.jp
+under.jp
+upper.jp
+velvet.jp
+verse.jp
+versus.jp
+vivian.jp
+watson.jp
+weblike.jp
+whitesnow.jp
+zombie.jp
+heteml.net
+
+// GOV.UK Platform as a Service : https://www.cloud.service.gov.uk/
+// Submitted by Tom Whitwell <gov-uk-paas-support@digital.cabinet-office.gov.uk>
+cloudapps.digital
+london.cloudapps.digital
+
+// GOV.UK Pay : https://www.payments.service.gov.uk/
+// Submitted by Richard Baker <richard.baker@digital.cabinet-office.gov.uk>
+pymnt.uk
 
 // UKHomeOffice : https://www.gov.uk/government/organisations/home-office
 // Submitted by Jon Shanks <jon.shanks@digital.homeoffice.gov.uk>
@@ -11356,7 +12177,6 @@ homeoffice.gov.uk
 // GlobeHosting, Inc.
 // Submitted by Zoltan Egresi <egresi@globehosting.com>
 ro.im
-shop.ro
 
 // GoIP DNS Services : http://www.goip.de
 // Submitted by Christian Poulter <milchstrasse@goip.de>
@@ -11364,8 +12184,24 @@ goip.de
 
 // Google, Inc.
 // Submitted by Eduardo Vela <evn@google.com>
+run.app
+a.run.app
+web.app
 *.0emm.com
 appspot.com
+*.r.appspot.com
+codespot.com
+googleapis.com
+googlecode.com
+pagespeedmobilizer.com
+publishproxy.com
+withgoogle.com
+withyoutube.com
+*.gateway.dev
+cloud.goog
+translate.goog
+*.usercontent.goog
+cloudfunctions.net
 blogspot.ae
 blogspot.al
 blogspot.am
@@ -11440,21 +12276,44 @@ blogspot.td
 blogspot.tw
 blogspot.ug
 blogspot.vn
-cloudfunctions.net
-codespot.com
-googleapis.com
-googlecode.com
-pagespeedmobilizer.com
-publishproxy.com
-withgoogle.com
-withyoutube.com
+
+// Goupile : https://goupile.fr
+// Submitted by Niels Martignene <hello@goupile.fr>
+goupile.fr
+
+// Group 53, LLC : https://www.group53.com
+// Submitted by Tyler Todd <noc@nova53.net>
+awsmppl.com
+
+// GünstigBestellen : https://günstigbestellen.de
+// Submitted by Furkan Akkoc <info@hendelzon.de>
+günstigbestellen.de
+günstigliefern.de
+
+// Hakaran group: http://hakaran.cz
+// Submitted by Arseniy Sokolov <security@hakaran.cz>
+fin.ci
+free.hr
+caa.li
+ua.rs
+conf.se
+
+// Handshake : https://handshake.org
+// Submitted by Mike Damm <md@md.vc>
+hs.zone
+hs.run
 
 // Hashbang : https://hashbang.sh
 hashbang.sh
 
 // Hasura : https://hasura.io
 // Submitted by Shahidh K Muhammed <shahidh@hasura.io>
+hasura.app
 hasura-app.io
+
+// Heilbronn University of Applied Sciences - Faculty Informatics (GitLab Pages): https://www.hs-heilbronn.de
+// Submitted by Richard Zowalla <mi-admin@hs-heilbronn.de>
+pages.it.hs-heilbronn.de
 
 // Hepforge : https://www.hepforge.org
 // Submitted by David Grellscheid <admin@hepforge.org>
@@ -11465,17 +12324,90 @@ hepforge.org
 herokuapp.com
 herokussl.com
 
+// Hibernating Rhinos
+// Submitted by Oren Eini <oren@ravendb.net>
+ravendb.cloud
+myravendb.com
+ravendb.community
+ravendb.me
+development.run
+ravendb.run
+
+// home.pl S.A.: https://home.pl
+// Submitted by Krzysztof Wolski <krzysztof.wolski@home.eu>
+homesklep.pl
+
+// Hong Kong Productivity Council: https://www.hkpc.org/
+// Submitted by SECaaS Team <summchan@hkpc.org>
+secaas.hk
+
+// Hoplix : https://www.hoplix.com
+// Submitted by Danilo De Franco<info@hoplix.shop>
+hoplix.shop
+
+
+// HOSTBIP REGISTRY : https://www.hostbip.com/
+// Submitted by Atanunu Igbunuroghene <publicsuffixlist@hostbip.com>
+orx.biz
+biz.gl
+col.ng
+firm.ng
+gen.ng
+ltd.ng
+ngo.ng
+edu.scot
+sch.so
+org.yt
+
+// HostyHosting (hostyhosting.com)
+hostyhosting.io
+
+// Häkkinen.fi
+// Submitted by Eero Häkkinen <Eero+psl@Häkkinen.fi>
+häkkinen.fi
+
 // Ici la Lune : http://www.icilalune.com/
 // Submitted by Simon Morvan <simon@icilalune.com>
+*.moonscale.io
 moonscale.net
 
 // iki.fi
 // Submitted by Hannu Aronsson <haa@iki.fi>
 iki.fi
 
+// Impertrix Solutions : <https://impertrixcdn.com>
+// Submitted by Zhixiang Zhao <csuite@impertrix.com>
+impertrixcdn.com
+impertrix.com
+
+// Incsub, LLC: https://incsub.com/
+// Submitted by Aaron Edwards <sysadmins@incsub.com>
+smushcdn.com
+wphostedmail.com
+wpmucdn.com
+tempurl.host
+wpmudev.host
+
+// Individual Network Berlin e.V. : https://www.in-berlin.de/
+// Submitted by Christian Seitz <chris@in-berlin.de>
+dyn-berlin.de
+in-berlin.de
+in-brb.de
+in-butter.de
+in-dsl.de
+in-dsl.net
+in-dsl.org
+in-vpn.de
+in-vpn.net
+in-vpn.org
+
 // info.at : http://www.info.at/
 biz.at
 info.at
+
+// info.cx : http://info.cx
+// Submitted by Jacob Slater <whois@igloo.to>
+info.cx
 
 // Interlegis : http://www.interlegis.leg.br
 // Submitted by Gabriel Ferreira <registrobr@interlegis.leg.br>
@@ -11507,9 +12439,130 @@ se.leg.br
 sp.leg.br
 to.leg.br
 
+// intermetrics GmbH : https://pixolino.com/
+// Submitted by Wolfgang Schwarz <admin@intermetrics.de>
+pixolino.com
+
+// Internet-Pro, LLP: https://netangels.ru/
+// Submitted by Vasiliy Sheredeko <piphon@gmail.com>
+na4u.ru
+
+// iopsys software solutions AB : https://iopsys.eu/
+// Submitted by Roman Azarenko <roman.azarenko@iopsys.eu>
+iopsys.se
+
 // IPiFony Systems, Inc. : https://www.ipifony.com/
 // Submitted by Matthew Hardeman <mhardeman@ipifony.com>
 ipifony.net
+
+// IServ GmbH : https://iserv.eu
+// Submitted by Kim-Alexander Brodowski <info@iserv.eu>
+mein-iserv.de
+schulserver.de
+test-iserv.de
+iserv.dev
+
+// I-O DATA DEVICE, INC. : http://www.iodata.com/
+// Submitted by Yuji Minagawa <domains-admin@iodata.jp>
+iobb.net
+
+// Jelastic, Inc. : https://jelastic.com/
+// Submitted by Ihor Kolodyuk <ik@jelastic.com>
+mel.cloudlets.com.au
+cloud.interhostsolutions.be
+users.scale.virtualcloud.com.br
+mycloud.by
+alp1.ae.flow.ch
+appengine.flow.ch
+es-1.axarnet.cloud
+diadem.cloud
+vip.jelastic.cloud
+jele.cloud
+it1.eur.aruba.jenv-aruba.cloud
+it1.jenv-aruba.cloud
+keliweb.cloud
+cs.keliweb.cloud
+oxa.cloud
+tn.oxa.cloud
+uk.oxa.cloud
+primetel.cloud
+uk.primetel.cloud
+ca.reclaim.cloud
+uk.reclaim.cloud
+us.reclaim.cloud
+ch.trendhosting.cloud
+de.trendhosting.cloud
+jele.club
+amscompute.com
+clicketcloud.com
+dopaas.com
+hidora.com
+paas.hosted-by-previder.com
+rag-cloud.hosteur.com
+rag-cloud-ch.hosteur.com
+jcloud.ik-server.com
+jcloud-ver-jpc.ik-server.com
+demo.jelastic.com
+kilatiron.com
+paas.massivegrid.com
+jed.wafaicloud.com
+lon.wafaicloud.com
+ryd.wafaicloud.com
+j.scaleforce.com.cy
+jelastic.dogado.eu
+fi.cloudplatform.fi
+demo.datacenter.fi
+paas.datacenter.fi
+jele.host
+mircloud.host
+paas.beebyte.io
+sekd1.beebyteapp.io
+jele.io
+cloud-fr1.unispace.io
+jc.neen.it
+cloud.jelastic.open.tim.it
+jcloud.kz
+upaas.kazteleport.kz
+cloudjiffy.net
+fra1-de.cloudjiffy.net
+west1-us.cloudjiffy.net
+jls-sto1.elastx.net
+jls-sto2.elastx.net
+jls-sto3.elastx.net
+faststacks.net
+fr-1.paas.massivegrid.net
+lon-1.paas.massivegrid.net
+lon-2.paas.massivegrid.net
+ny-1.paas.massivegrid.net
+ny-2.paas.massivegrid.net
+sg-1.paas.massivegrid.net
+jelastic.saveincloud.net
+nordeste-idc.saveincloud.net
+j.scaleforce.net
+jelastic.tsukaeru.net
+sdscloud.pl
+unicloud.pl
+mircloud.ru
+jelastic.regruhosting.ru
+enscaled.sg
+jele.site
+jelastic.team
+orangecloud.tn
+j.layershift.co.uk
+phx.enscaled.us
+mircloud.us
+
+// Jino : https://www.jino.ru
+// Submitted by Sergey Ulyashin <ulyashin@jino.ru>
+myjino.ru
+*.hosting.myjino.ru
+*.landing.myjino.ru
+*.spectrum.myjino.ru
+*.vps.myjino.ru
+
+// Jotelulu S.L. : https://jotelulu.com
+// Submitted by Daniel Fariña <ingenieria@jotelulu.com>
+jotelulu.cloud
 
 // Joyent : https://www.joyent.com/
 // Submitted by Brian Bennett <brian.bennett@joyent.com>
@@ -11520,25 +12573,221 @@ ipifony.net
 // Submitted by Stefan Keim <admin@js.org>
 js.org
 
+// KaasHosting : http://www.kaashosting.nl/
+// Submitted by Wouter Bakker <hostmaster@kaashosting.nl>
+kaas.gg
+khplay.nl
+
+// Kakao : https://www.kakaocorp.com/
+// Submitted by JaeYoong Lee <cec@kakaocorp.com>
+ktistory.com
+
+// Kapsi : https://kapsi.fi
+// Submitted by Tomi Juntunen <erani@kapsi.fi>
+kapsi.fi
+
 // Keyweb AG : https://www.keyweb.de
 // Submitted by Martin Dannehl <postmaster@keymachine.de>
 keymachine.de
+
+// KingHost : https://king.host
+// Submitted by Felipe Keller Braz <felipebraz@kinghost.com.br>
+kinghost.net
+uni5.net
 
 // KnightPoint Systems, LLC : http://www.knightpoint.com/
 // Submitted by Roy Keene <rkeene@knightpoint.com>
 knightpoint.systems
 
+// KoobinEvent, SL: https://www.koobin.com
+// Submitted by Iván Oliva <ivan.oliva@koobin.com>
+koobin.events
+
+// KUROKU LTD : https://kuroku.ltd/
+// Submitted by DisposaBoy <security@oya.to>
+oya.to
+
+// Katholieke Universiteit Leuven: https://www.kuleuven.be
+// Submitted by Abuse KU Leuven <abuse@kuleuven.be>
+kuleuven.cloud
+ezproxy.kuleuven.be
+
 // .KRD : http://nic.krd/data/krd/Registration%20Policy.pdf
 co.krd
 edu.krd
+
+// Krellian Ltd. : https://krellian.com
+// Submitted by Ben Francis <ben@krellian.com>
+krellian.net
+webthings.io
+
+// LCube - Professional hosting e.K. : https://www.lcube-webhosting.de
+// Submitted by Lars Laehn <info@lcube.de>
+git-repos.de
+lcube-server.de
+svn-repos.de
+
+// Leadpages : https://www.leadpages.net
+// Submitted by Greg Dallavalle <domains@leadpages.net>
+leadpages.co
+lpages.co
+lpusercontent.com
+
+// Lelux.fi : https://lelux.fi/
+// Submitted by Lelux Admin <publisuffix@lelux.site>
+lelux.site
+
+// Lifetime Hosting : https://Lifetime.Hosting/
+// Submitted by Mike Fillator <support@lifetime.hosting>
+co.business
+co.education
+co.events
+co.financial
+co.network
+co.place
+co.technology
+
+// Lightmaker Property Manager, Inc. : https://app.lmpm.com/
+// Submitted by Greg Holland <greg.holland@lmpm.com>
+app.lmpm.com
+
+// linkyard ldt: https://www.linkyard.ch/
+// Submitted by Mario Siegenthaler <mario.siegenthaler@linkyard.ch>
+linkyard.cloud
+linkyard-cloud.ch
+
+// Linode : https://linode.com
+// Submitted by <security@linode.com>
+members.linode.com
+*.nodebalancer.linode.com
+*.linodeobjects.com
+ip.linodeusercontent.com
+
+// LiquidNet Ltd : http://www.liquidnetlimited.com/
+// Submitted by Victor Velchev <admin@liquidnetlimited.com>
+we.bs
+
+// Localcert : https://localcert.dev
+// Submitted by Lann Martin <security@localcert.dev>
+*.user.localcert.dev
+
+// localzone.xyz
+// Submitted by Kenny Niehage <hello@yahe.sh>
+localzone.xyz
+
+// Log'in Line : https://www.loginline.com/
+// Submitted by Rémi Mach <remi.mach@loginline.com>
+loginline.app
+loginline.dev
+loginline.io
+loginline.services
+loginline.site
+
+// Lokalized : https://lokalized.nl
+// Submitted by Noah Taheij <noah@lokalized.nl>
+servers.run
+
+// Lõhmus Family, The
+// Submitted by Heiki Lõhmus <hostmaster at lohmus dot me>
+lohmus.me
+
+// LubMAN UMCS Sp. z o.o : https://lubman.pl/
+// Submitted by Ireneusz Maliszewski <ireneusz.maliszewski@lubman.pl>
+krasnik.pl
+leczna.pl
+lubartow.pl
+lublin.pl
+poniatowa.pl
+swidnik.pl
+
+// Lug.org.uk : https://lug.org.uk
+// Submitted by Jon Spriggs <admin@lug.org.uk>
+glug.org.uk
+lug.org.uk
+lugs.org.uk
+
+// Lukanet Ltd : https://lukanet.com
+// Submitted by Anton Avramov <register@lukanet.com>
+barsy.bg
+barsy.co.uk
+barsyonline.co.uk
+barsycenter.com
+barsyonline.com
+barsy.club
+barsy.de
+barsy.eu
+barsy.in
+barsy.info
+barsy.io
+barsy.me
+barsy.menu
+barsy.mobi
+barsy.net
+barsy.online
+barsy.org
+barsy.pro
+barsy.pub
+barsy.ro
+barsy.shop
+barsy.site
+barsy.support
+barsy.uk
 
 // Magento Commerce
 // Submitted by Damien Tournoud <dtournoud@magento.cloud>
 *.magentosite.cloud
 
+// May First - People Link : https://mayfirst.org/
+// Submitted by Jamie McClelland <info@mayfirst.org>
+mayfirst.info
+mayfirst.org
+
 // Mail.Ru Group : https://hb.cldmail.ru
 // Submitted by Ilya Zaretskiy <zaretskiy@corp.mail.ru>
 hb.cldmail.ru
+
+// Mail Transfer Platform : https://www.neupeer.com
+// Submitted by Li Hui <lihui@neupeer.com>
+cn.vu
+
+// Maze Play: https://www.mazeplay.com
+// Submitted by Adam Humpherys <adam@mws.dev>
+mazeplay.com
+
+// mcpe.me : https://mcpe.me
+// Submitted by Noa Heyl <hi@noa.dev>
+mcpe.me
+
+// McHost : https://mchost.ru
+// Submitted by Evgeniy Subbotin <e.subbotin@mchost.ru>
+mcdir.me
+mcdir.ru
+mcpre.ru
+vps.mcdir.ru
+
+// Mediatech : https://mediatech.by
+// Submitted by Evgeniy Kozhuhovskiy <ugenk@mediatech.by>
+mediatech.by
+mediatech.dev
+
+// Medicom Health : https://medicomhealth.com
+// Submitted by Michael Olson <molson@medicomhealth.com>
+hra.health
+
+// Memset hosting : https://www.memset.com
+// Submitted by Tom Whitwell <domains@memset.com>
+miniserver.com
+memset.net
+
+// MetaCentrum, CESNET z.s.p.o. : https://www.metacentrum.cz/en/
+// Submitted by Zdeněk Šustr <zdenek.sustr@cesnet.cz>
+*.cloud.metacentrum.cz
+custom.metacentrum.cz
+
+// MetaCentrum, CESNET z.s.p.o. : https://www.metacentrum.cz/en/
+// Submitted by Radim Janča <janca@cesnet.cz>
+flt.cloud.muni.cz
+usr.cloud.muni.cz
 
 // Meteor Development Group : https://www.meteor.com/hosting
 // Submitted by Pierre Carrier <pierre@meteor.com>
@@ -11548,15 +12797,92 @@ eu.meteorapp.com
 // Michau Enterprises Limited : http://www.co.pl/
 co.pl
 
-// Microsoft : http://microsoft.com
-// Submitted by Barry Dorrans <bdorrans@microsoft.com>
+// Microsoft Corporation : http://microsoft.com
+// Submitted by Public Suffix List Admin <msftpsladmin@microsoft.com>
+*.azurecontainer.io
 azurewebsites.net
 azure-mobile.net
 cloudapp.net
+azurestaticapps.net
+1.azurestaticapps.net
+centralus.azurestaticapps.net
+eastasia.azurestaticapps.net
+eastus2.azurestaticapps.net
+westeurope.azurestaticapps.net
+westus2.azurestaticapps.net
+
+// minion.systems : http://minion.systems
+// Submitted by Robert Böttinger <r@minion.systems>
+csx.cc
+
+// Mintere : https://mintere.com/
+// Submitted by Ben Aubin <security@mintere.com>
+mintere.site
+
+// MobileEducation, LLC : https://joinforte.com
+// Submitted by Grayson Martin <grayson.martin@mobileeducation.us>
+forte.id
+
+// Mozilla Corporation : https://mozilla.com
+// Submitted by Ben Francis <bfrancis@mozilla.com>
+mozilla-iot.org
 
 // Mozilla Foundation : https://mozilla.org/
 // Submitted by glob <glob@mozilla.com>
 bmoattachments.org
+
+// MSK-IX : https://www.msk-ix.ru/
+// Submitted by Khannanov Roman <r.khannanov@msk-ix.ru>
+net.ru
+org.ru
+pp.ru
+
+// Mythic Beasts : https://www.mythic-beasts.com
+// Submitted by Paul Cammish <kelduum@mythic-beasts.com>
+hostedpi.com
+customer.mythic-beasts.com
+caracal.mythic-beasts.com
+fentiger.mythic-beasts.com
+lynx.mythic-beasts.com
+ocelot.mythic-beasts.com
+oncilla.mythic-beasts.com
+onza.mythic-beasts.com
+sphinx.mythic-beasts.com
+vs.mythic-beasts.com
+x.mythic-beasts.com
+yali.mythic-beasts.com
+cust.retrosnub.co.uk
+
+// Nabu Casa : https://www.nabucasa.com
+// Submitted by Paulus Schoutsen <infra@nabucasa.com>
+ui.nabu.casa
+
+// Names.of.London : https://names.of.london/
+// Submitted by James Stevens <registry[at]names.of.london> or <publiclist[at]jrcs.net>
+pony.club
+of.fashion
+in.london
+of.london
+from.marketing
+with.marketing
+for.men
+repair.men
+and.mom
+for.mom
+for.one
+under.one
+for.sale
+that.win
+from.work
+to.work
+
+// Net at Work Gmbh : https://www.netatwork.de
+// Submitted by Jan Jaeschke <jan.jaeschke@netatwork.de>
+cloud.nospamproxy.com
+
+// Netlify : https://www.netlify.com
+// Submitted by Jessica Parsons <jessica@netlify.com>
+netlify.app
 
 // Neustar Inc.
 // Submitted by Trung Tran <Trung.Tran@neustar.biz>
@@ -11566,9 +12892,58 @@ bmoattachments.org
 // Submitted by Alan Shreve <alan@ngrok.com>
 ngrok.io
 
+// Nimbus Hosting Ltd. : https://www.nimbushosting.co.uk/
+// Submitted by Nicholas Ford <nick@nimbushosting.co.uk>
+nh-serv.co.uk
+
 // NFSN, Inc. : https://www.NearlyFreeSpeech.NET/
 // Submitted by Jeff Wheelhouse <support@nearlyfreespeech.net>
 nfshost.com
+
+// Noop : https://noop.app
+// Submitted by Nathaniel Schweinberg <noop@rearc.io>
+*.developer.app
+noop.app
+
+// Northflank Ltd. : https://northflank.com/
+// Submitted by Marco Suter <marco@northflank.com>
+*.northflank.app
+*.build.run
+*.code.run
+*.database.run
+*.migration.run
+
+// Noticeable : https://noticeable.io
+// Submitted by Laurent Pellegrino <security@noticeable.io>
+noticeable.news
+
+// Now-DNS : https://now-dns.com
+// Submitted by Steve Russell <steve@now-dns.com>
+dnsking.ch
+mypi.co
+n4t.co
+001www.com
+ddnslive.com
+myiphost.com
+forumz.info
+16-b.it
+32-b.it
+64-b.it
+soundcast.me
+tcp4.me
+dnsup.net
+hicam.net
+now-dns.net
+ownip.net
+vpndns.net
+dynserv.org
+now-dns.org
+x443.pw
+now-dns.top
+ntdll.top
+freeddns.us
+crafting.xyz
+zapto.xyz
 
 // nsupdate.info : https://www.nsupdate.info/
 // Submitted by Thomas Waldmann <info@nsupdate.info>
@@ -11663,33 +13038,93 @@ sytes.net
 webhop.me
 zapto.org
 
+// NodeArt : https://nodeart.io
+// Submitted by Konstantin Nosov <Nosov@nodeart.io>
+stage.nodeart.io
+
+// Nucleos Inc. : https://nucleos.com
+// Submitted by Piotr Zduniak <piotr@nucleos.com>
+pcloud.host
+
 // NYC.mn : http://www.information.nyc.mn
 // Submitted by Matthew Brown <mattbrown@nyc.mn>
 nyc.mn
+
+// Observable, Inc. : https://observablehq.com
+// Submitted by Mike Bostock <dns@observablehq.com>
+static.observableusercontent.com
 
 // Octopodal Solutions, LLC. : https://ulterius.io/
 // Submitted by Andrew Sampson <andrew@ulterius.io>
 cya.gg
 
+// OMG.LOL : <https://omg.lol>
+// Submitted by Adam Newbold <adam@omg.lol>
+omg.lol
+
+// Omnibond Systems, LLC. : https://www.omnibond.com
+// Submitted by Cole Estep <cole@omnibond.com>
+cloudycluster.net
+
+// OmniWe Limited: https://omniwe.com
+// Submitted by Vicary Archangel <vicary@omniwe.com>
+omniwe.site
+
+// One.com: https://www.one.com/
+// Submitted by Jacob Bunk Nielsen <jbn@one.com>
+service.one
+
 // One Fold Media : http://www.onefoldmedia.com/
 // Submitted by Eddie Jones <eddie@onefoldmedia.com>
 nid.io
+
+// Open Social : https://www.getopensocial.com/
+// Submitted by Alexander Varwijk <security@getopensocial.com>
+opensocial.site
 
 // OpenCraft GmbH : http://opencraft.com/
 // Submitted by Sven Marnach <sven@opencraft.com>
 opencraft.hosting
 
+// OpenResearch GmbH: https://openresearch.com/
+// Submitted by Philipp Schmid <ops@openresearch.com>
+orsites.com
+
 // Opera Software, A.S.A.
 // Submitted by Yngve Pettersen <yngve@opera.com>
 operaunite.com
+
+// Orange : https://www.orange.com
+// Submitted by Alexandre Linte <alexandre.linte@orange.com>
+tech.orange
+
+// Oursky Limited : https://authgear.com/, https://skygear.io/
+// Submitted by Authgear Team <hello@authgear.com>, Skygear Developer <hello@skygear.io>
+authgear-staging.com
+authgearapps.com
+skygearapp.com
 
 // OutSystems
 // Submitted by Duarte Santos <domain-admin@outsystemscloud.com>
 outsystemscloud.com
 
-// OwnProvider : http://www.ownprovider.com
+// OVHcloud: https://ovhcloud.com
+// Submitted by Vincent Cassé <vincent.casse@ovhcloud.com>
+*.webpaas.ovh.net
+*.hosting.ovh.net
+
+// OwnProvider GmbH: http://www.ownprovider.com
 // Submitted by Jan Moennich <jan.moennich@ownprovider.com>
 ownprovider.com
+own.pm
+
+// OwO : https://whats-th.is/
+// Submitted by Dean Sheather <dean@deansheather.com>
+*.owo.codes
+
+// OX : http://www.ox.rs
+// Submitted by Adam Grand <webmaster@mail.ox.rs>
+ox.rs
 
 // oy.lc
 // Submitted by Charly Coste <changaco@changaco.oy.lc>
@@ -11702,6 +13137,21 @@ pgfog.com
 // Pagefront : https://www.pagefronthq.com/
 // Submitted by Jason Kriss <jason@pagefronthq.com>
 pagefrontapp.com
+
+// PageXL : https://pagexl.com
+// Submitted by Yann Guichard <yann@pagexl.com>
+pagexl.com
+
+// Paywhirl, Inc : https://paywhirl.com/
+// Submitted by Daniel Netzer <dan@paywhirl.com>
+*.paywhirl.com
+
+// pcarrier.ca Software Inc: https://pcarrier.ca/
+// Submitted by Pierre Carrier <pc@rrier.ca>
+bar0.net
+bar1.net
+bar2.net
+rdv.to
 
 // .pl domains (grandfathered)
 art.pl
@@ -11720,14 +13170,61 @@ gotpantheon.com
 // Submitted by Steve Leung <steveleung@peplink.com>
 mypep.link
 
+// Perspecta : https://perspecta.com/
+// Submitted by Kenneth Van Alstyne <kvanalstyne@perspecta.com>
+perspecta.cloud
+
+// PE Ulyanov Kirill Sergeevich : https://airy.host
+// Submitted by Kirill Ulyanov <k.ulyanov@airy.host>
+lk3.ru
+
 // Planet-Work : https://www.planet-work.com/
 // Submitted by Frédéric VANNIÈRE <f.vanniere@planet-work.com>
 on-web.fr
 
 // Platform.sh : https://platform.sh
 // Submitted by Nikola Kotur <nikola@platform.sh>
-*.platform.sh
+bc.platform.sh
+ent.platform.sh
+eu.platform.sh
+us.platform.sh
 *.platformsh.site
+*.tst.site
+
+// Platter: https://platter.dev
+// Submitted by Patrick Flor <patrick@platter.dev>
+platter-app.com
+platter-app.dev
+platterp.us
+
+// Plesk : https://www.plesk.com/
+// Submitted by Anton Akhtyamov <program-managers@plesk.com>
+pdns.page
+plesk.page
+pleskns.com
+
+// Port53 : https://port53.io/
+// Submitted by Maximilian Schieder <maxi@zeug.co>
+dyn53.io
+
+// Porter : https://porter.run/
+// Submitted by Rudraksh MK <rudi@porter.run>
+onporter.run
+
+// Positive Codes Technology Company : http://co.bn/faq.html
+// Submitted by Zulfais <pc@co.bn>
+co.bn
+
+// Postman, Inc : https://postman.com
+// Submitted by Rahul Dhawan <security@postman.com>
+postman-echo.com
+pstmn.io
+mock.pstmn.io
+httpbin.org
+
+//prequalifyme.today : https://prequalifyme.today
+//Submitted by DeepakTiwari deepak@ivylead.io
+prequalifyme.today
 
 // prgmr.com : https://prgmr.com/
 // Submitted by Sarah Newman <owner@prgmr.com>
@@ -11737,6 +13234,14 @@ xen.prgmr.com
 // Submitted by registry <lendl@nic.at>
 priv.at
 
+// privacytools.io : https://www.privacytools.io/
+// Submitted by Jonah Aragon <jonah@privacytools.io>
+prvcy.page
+
+// Protocol Labs : https://protocol.ai/
+// Submitted by Michael Burns <noc@protocol.ai>
+*.dweb.link
+
 // Protonet GmbH : http://protonet.io
 // Submitted by Martin Meier <admin@protonet.io>
 protonet.io
@@ -11744,10 +13249,53 @@ protonet.io
 // Publication Presse Communication SARL : https://ppcom.fr
 // Submitted by Yaacov Akiba Slama <admin@chirurgiens-dentistes-en-france.fr>
 chirurgiens-dentistes-en-france.fr
+byen.site
+
+// pubtls.org: https://www.pubtls.org
+// Submitted by Kor Nielsen <kor@pubtls.org>
+pubtls.org
+
+// PythonAnywhere LLP: https://www.pythonanywhere.com
+// Submitted by Giles Thomas <giles@pythonanywhere.com>
+pythonanywhere.com
+eu.pythonanywhere.com
+
+// QOTO, Org.
+// Submitted by Jeffrey Phillips Freeman <jeffrey.freeman@qoto.org>
+qoto.io
+
+// Qualifio : https://qualifio.com/
+// Submitted by Xavier De Cock <xdecock@gmail.com>
+qualifioapp.com
+
+// QuickBackend: https://www.quickbackend.com
+// Submitted by Dani Biro <dani@pymet.com>
+qbuser.com
+
+// Rad Web Hosting: https://radwebhosting.com
+// Submitted by Scott Claeys <s.claeys@radwebhosting.com>
+cloudsite.builders
+
+// Redgate Software: https://red-gate.com
+// Submitted by Andrew Farries <andrew.farries@red-gate.com>
+instances.spawn.cc
+
+// Redstar Consultants : https://www.redstarconsultants.com/
+// Submitted by Jons Slemmer <jons@redstarconsultants.com>
+instantcloud.cn
+
+// Russian Academy of Sciences
+// Submitted by Tech Support <support@rasnet.ru>
+ras.ru
 
 // QA2
 // Submitted by Daniel Dent (https://www.danieldent.com/)
 qa2.com
+
+// QCX
+// Submitted by Cassandra Beelen <cassandra@beelen.one>
+qcx.io
+*.sys.qcx.io
 
 // QNAP System Inc : https://www.qnap.com
 // Submitted by Nick Chang <nickchang@qnap.com>
@@ -11769,9 +13317,39 @@ vaporcloud.io
 rackmaze.com
 rackmaze.net
 
+// Rakuten Games, Inc : https://dev.viberplay.io
+// Submitted by Joshua Zhang <public-suffix@rgames.jp>
+g.vbrplsbx.io
+
+// Rancher Labs, Inc : https://rancher.com
+// Submitted by Vincent Fiduccia <domains@rancher.com>
+*.on-k3s.io
+*.on-rancher.cloud
+*.on-rio.io
+
+// Read The Docs, Inc : https://www.readthedocs.org
+// Submitted by David Fischer <team@readthedocs.org>
+readthedocs.io
+
 // Red Hat, Inc. OpenShift : https://openshift.redhat.com/
 // Submitted by Tim Kramer <tkramer@rhcloud.com>
 rhcloud.com
+
+// Render : https://render.com
+// Submitted by Anurag Goel <dev@render.com>
+app.render.com
+onrender.com
+
+// Repl.it : https://repl.it
+// Submitted by Mason Clayton <mason@repl.it>
+repl.co
+id.repl.co
+repl.run
+
+// Resin.io : https://resin.io
+// Submitted by Tim Perry <tim@resin.io>
+resindevice.io
+devices.resinstaging.io
 
 // RethinkDB : https://www.rethinkdb.com/
 // Submitted by Chris Kastorff <info@rethinkdb.com>
@@ -11780,8 +13358,36 @@ hzc.io
 // Revitalised Limited : http://www.revitalised.co.uk
 // Submitted by Jack Price <jack@revitalised.co.uk>
 wellbeingzone.eu
-ptplus.fit
 wellbeingzone.co.uk
+
+// Rico Developments Limited : https://adimo.co
+// Submitted by Colin Brown <hello@adimo.co>
+adimo.co.uk
+
+// Riseup Networks : https://riseup.net
+// Submitted by Micah Anderson <micah@riseup.net>
+itcouldbewor.se
+
+// Rochester Institute of Technology : http://www.rit.edu/
+// Submitted by Jennifer Herting <jchits@rit.edu>
+git-pages.rit.edu
+
+// Rocky Enterprise Software Foundation : https://resf.org
+// Submitted by Neil Hanlon <neil@resf.org>
+rocky.page
+
+// Rusnames Limited: http://rusnames.ru/
+// Submitted by Sergey Zotov <admin@rusnames.ru>
+биз.рус
+ком.рус
+крым.рус
+мир.рус
+мск.рус
+орг.рус
+самара.рус
+сочи.рус
+спб.рус
+я.рус
 
 // Sandstorm Development Group, Inc. : https://sandcats.io/
 // Submitted by Asheesh Laroia <asheesh@sandstorm.io>
@@ -11791,6 +13397,47 @@ sandcats.io
 // Submitted by Norman Meilick <nm@sbe.de>
 logoip.de
 logoip.com
+
+// Scaleway : https://www.scaleway.com/
+// Submitted by Rémy Léone <rleone@scaleway.com>
+fr-par-1.baremetal.scw.cloud
+fr-par-2.baremetal.scw.cloud
+nl-ams-1.baremetal.scw.cloud
+fnc.fr-par.scw.cloud
+functions.fnc.fr-par.scw.cloud
+k8s.fr-par.scw.cloud
+nodes.k8s.fr-par.scw.cloud
+s3.fr-par.scw.cloud
+s3-website.fr-par.scw.cloud
+whm.fr-par.scw.cloud
+priv.instances.scw.cloud
+pub.instances.scw.cloud
+k8s.scw.cloud
+k8s.nl-ams.scw.cloud
+nodes.k8s.nl-ams.scw.cloud
+s3.nl-ams.scw.cloud
+s3-website.nl-ams.scw.cloud
+whm.nl-ams.scw.cloud
+k8s.pl-waw.scw.cloud
+nodes.k8s.pl-waw.scw.cloud
+s3.pl-waw.scw.cloud
+s3-website.pl-waw.scw.cloud
+scalebook.scw.cloud
+smartlabeling.scw.cloud
+dedibox.fr
+
+// schokokeks.org GbR : https://schokokeks.org/
+// Submitted by Hanno Böck <hanno@schokokeks.org>
+schokokeks.net
+
+// Scottish Government: https://www.gov.scot
+// Submitted by Martin Ellis <martin.ellis@gov.scot>
+gov.scot
+service.gov.scot
+
+// Scry Security : http://www.scrysec.com
+// Submitted by Shante Adam <shante@skyhat.io>
+scrysec.com
 
 // Securepoint GmbH : https://www.securepoint.de
 // Submitted by Erik Anders <erik.anders@securepoint.de>
@@ -11805,15 +13452,36 @@ my-firewall.org
 myfirewall.org
 spdns.org
 
-// SensioLabs, SAS : https://sensiolabs.com/
-// Submitted by Fabien Potencier <fabien.potencier@sensiolabs.com>
-*.sensiosite.cloud
+// Seidat : https://www.seidat.com
+// Submitted by Artem Kondratev <accounts@seidat.com>
+seidat.net
+
+// Sellfy : https://sellfy.com
+// Submitted by Yuriy Romadin <contact@sellfy.com>
+sellfy.store
+
+// Senseering GmbH : https://www.senseering.de
+// Submitted by Felix Mönckemeyer <f.moenckemeyer@senseering.de>
+senseering.net
+
+// Sendmsg: https://www.sendmsg.co.il
+// Submitted by Assaf Stern <domains@comstar.co.il>
+minisite.ms
+
+// Service Magnet : https://myservicemagnet.com
+// Submitted by Dave Sanders <dave@myservicemagnet.com>
+magnet.page
 
 // Service Online LLC : http://drs.ua/
 // Submitted by Serhii Bulakh <support@drs.ua>
 biz.ua
 co.ua
 pp.ua
+
+// Shift Crypto AG : https://shiftcrypto.ch
+// Submitted by alex <alex@shiftcrypto.ch>
+shiftcrypto.dev
+shiftcrypto.io
 
 // ShiftEdit : https://shiftedit.net/
 // Submitted by Adam Jimenez <adam@shiftcreate.com>
@@ -11823,6 +13491,22 @@ shiftedit.io
 // Submitted by Alex Bowers <alex@shopblocks.com>
 myshopblocks.com
 
+// Shopify : https://www.shopify.com
+// Submitted by Alex Richter <alex.richter@shopify.com>
+myshopify.com
+
+// Shopit : https://www.shopitcommerce.com/
+// Submitted by Craig McMahon <craig@shopitcommerce.com>
+shopitsite.com
+
+// shopware AG : https://shopware.com
+// Submitted by Jens Küper <cloud@shopware.com>
+shopware.store
+
+// Siemens Mobility GmbH
+// Submitted by Oliver Graebner <security@mo-siemens.io>
+mo-siemens.io
+
 // SinaAppEngine : http://sae.sina.com.cn/
 // Submitted by SinaAppEngine <saesupport@sinacloud.com>
 1kapp.com
@@ -11831,17 +13515,62 @@ applinzi.com
 sinaapp.com
 vipsinaapp.com
 
+// Siteleaf : https://www.siteleaf.com/
+// Submitted by Skylar Challand <support@siteleaf.com>
+siteleaf.net
+
 // Skyhat : http://www.skyhat.io
 // Submitted by Shante Adam <shante@skyhat.io>
 bounty-full.com
 alpha.bounty-full.com
 beta.bounty-full.com
 
+// Small Technology Foundation : https://small-tech.org
+// Submitted by Aral Balkan <aral@small-tech.org>
+small-web.org
+
+// Smoove.io : https://www.smoove.io/
+// Submitted by Dan Kozak <dan@smoove.io>
+vp4.me
+
+// Snowplow Analytics : https://snowplowanalytics.com/
+// Submitted by Ian Streeter <ian@snowplowanalytics.com>
+try-snowplow.com
+
+// SourceHut : https://sourcehut.org
+// Submitted by Drew DeVault <sir@cmpwn.com>
+srht.site
+
+// Stackhero : https://www.stackhero.io
+// Submitted by Adrien Gillon <adrien+public-suffix-list@stackhero.io>
+stackhero-network.com
+
+// Staclar : https://staclar.com
+// Submitted by Q Misell <q@staclar.com>
+musician.io
+// Submitted by Matthias Merkel <matthias.merkel@staclar.com>
+novecore.site
+
 // staticland : https://static.land
 // Submitted by Seth Vincent <sethvincent@gmail.com>
 static.land
 dev.static.land
 sites.static.land
+
+// Storebase : https://www.storebase.io
+// Submitted by Tony Schirmer <tony@storebase.io>
+storebase.store
+
+// Strategic System Consulting (eApps Hosting): https://www.eapps.com/
+// Submitted by Alex Oancea <aoancea@cloudscale365.com>
+vps-host.net
+atl.jelastic.vps-host.net
+njs.jelastic.vps-host.net
+ric.jelastic.vps-host.net
+
+// Sony Interactive Entertainment LLC : https://sie.com/
+// Submitted by David Coles <david.coles@sony.com>
+playstation-cloud.com
 
 // SourceLair PC : https://www.sourcelair.com
 // Submitted by Antonis Kalipetis <akalipetis@sourcelair.com>
@@ -11852,34 +13581,100 @@ apps.lair.io
 // Submitted by Reza Akhavan <spacekit.io@gmail.com>
 spacekit.io
 
-// Stackspace : https://www.stackspace.io/
-// Submitted by Lina He <info@stackspace.io>
-stackspace.space
+// SpeedPartner GmbH: https://www.speedpartner.de/
+// Submitted by Stefan Neufeind <info@speedpartner.de>
+customer.speedpartner.de
+
+// Spreadshop (sprd.net AG) : https://www.spreadshop.com/
+// Submitted by Martin Breest <security@spreadshop.com>
+myspreadshop.at
+myspreadshop.com.au
+myspreadshop.be
+myspreadshop.ca
+myspreadshop.ch
+myspreadshop.com
+myspreadshop.de
+myspreadshop.dk
+myspreadshop.es
+myspreadshop.fi
+myspreadshop.fr
+myspreadshop.ie
+myspreadshop.it
+myspreadshop.net
+myspreadshop.nl
+myspreadshop.no
+myspreadshop.pl
+myspreadshop.se
+myspreadshop.co.uk
+
+// Standard Library : https://stdlib.com
+// Submitted by Jacob Lee <jacob@stdlib.com>
+api.stdlib.com
 
 // Storj Labs Inc. : https://storj.io/
 // Submitted by Philip Hutchins <hostmaster@storj.io>
 storj.farm
 
+// Studenten Net Twente : http://www.snt.utwente.nl/
+// Submitted by Silke Hofstra <syscom@snt.utwente.nl>
+utwente.io
+
+// Student-Run Computing Facility : https://www.srcf.net/
+// Submitted by Edwin Balani <sysadmins@srcf.net>
+soc.srcf.net
+user.srcf.net
+
+// Sub 6 Limited: http://www.sub6.com
+// Submitted by Dan Miller <dm@sub6.com>
+temp-dns.com
+
+// Supabase : https://supabase.io
+// Submitted by Inian Parameshwaran <security@supabase.io>
+supabase.co
+supabase.in
+supabase.net
+su.paba.se
+
+// Symfony, SAS : https://symfony.com/
+// Submitted by Fabien Potencier <fabien@symfony.com>
+*.s5y.io
+*.sensiosite.cloud
+
+// Syncloud : https://syncloud.org
+// Submitted by Boris Rybalkin <syncloud@syncloud.it>
+syncloud.it
+
 // Synology, Inc. : https://www.synology.com/
 // Submitted by Rony Weng <ronyweng@synology.com>
-diskstation.me
 dscloud.biz
-dscloud.me
-dscloud.mobi
+direct.quickconnect.cn
 dsmynas.com
-dsmynas.net
-dsmynas.org
 familyds.com
-familyds.net
-familyds.org
+diskstation.me
+dscloud.me
 i234.me
 myds.me
 synology.me
+dscloud.mobi
+dsmynas.net
+familyds.net
+dsmynas.org
+familyds.org
 vpnplus.to
+direct.quickconnect.to
+
+// Tabit Technologies Ltd. : https://tabit.cloud/
+// Submitted by Oren Agiv <oren@tabit.cloud>
+tabitorder.co.il
 
 // TAIFUN Software AG : http://taifun-software.de
 // Submitted by Bjoern Henke <dev-server@taifun-software.de>
 taifun-dns.de
+
+// Tailscale Inc. : https://www.tailscale.com
+// Submitted by David Anderson <danderson@tailscale.com>
+beta.tailscale.net
+ts.net
 
 // TASK geographical domains (www.task.gda.pl/uslugi/dns)
 gda.pl
@@ -11888,16 +13683,94 @@ gdynia.pl
 med.pl
 sopot.pl
 
+// team.blue https://team.blue
+// Submitted by Cedric Dubois <cedric.dubois@team.blue>
+site.tb-hosting.com
+
+// Teckids e.V. : https://www.teckids.org
+// Submitted by Dominik George <dominik.george@teckids.org>
+edugit.io
+s3.teckids.org
+
+// Telebit : https://telebit.cloud
+// Submitted by AJ ONeal <aj@telebit.cloud>
+telebit.app
+telebit.io
+*.telebit.xyz
+
+// The Gwiddle Foundation : https://gwiddlefoundation.org.uk
+// Submitted by Joshua Bayfield <joshua.bayfield@gwiddlefoundation.org.uk>
+gwiddle.co.uk
+
+// Thingdust AG : https://thingdust.com/
+// Submitted by Adrian Imboden <adi@thingdust.com>
+*.firenet.ch
+*.svc.firenet.ch
+reservd.com
+thingdustdata.com
+cust.dev.thingdust.io
+cust.disrec.thingdust.io
+cust.prod.thingdust.io
+cust.testing.thingdust.io
+reservd.dev.thingdust.io
+reservd.disrec.thingdust.io
+reservd.testing.thingdust.io
+
+// ticket i/O GmbH : https://ticket.io
+// Submitted by Christian Franke <it@ticket.io>
+tickets.io
+
+// Tlon.io : https://tlon.io
+// Submitted by Mark Staarink <mark@tlon.io>
+arvo.network
+azimuth.network
+tlon.network
+
+// Tor Project, Inc. : https://torproject.org
+// Submitted by Antoine Beaupré <anarcat@torproject.org
+torproject.net
+pages.torproject.net
+
 // TownNews.com : http://www.townnews.com
 // Submitted by Dustin Ward <dward@townnews.com>
 bloxcms.com
 townnews-staging.com
 
-// TransIP : htts://www.transip.nl
+// TradableBits: https://tradablebits.com
+// Submitted by Dmitry Khrisanov dmitry@tradablebits.com
+tbits.me
+
+// TrafficPlex GmbH : https://www.trafficplex.de/
+// Submitted by Phillipp Röll <phillipp.roell@trafficplex.de>
+12hp.at
+2ix.at
+4lima.at
+lima-city.at
+12hp.ch
+2ix.ch
+4lima.ch
+lima-city.ch
+trafficplex.cloud
+de.cool
+12hp.de
+2ix.de
+4lima.de
+lima-city.de
+1337.pictures
+clan.rip
+lima-city.rocks
+webspace.rocks
+lima.zone
+
+// TransIP : https://www.transip.nl
 // Submitted by Rory Breuk <rbreuk@transip.nl>
 *.transurl.be
 *.transurl.eu
 *.transurl.nl
+
+// TransIP: https://www.transip.nl
+// Submitted by Cedric Dubois <cedric.dubois@team.blue>
+site.transip.me
 
 // TuxFamily : http://tuxfamily.org
 // Submitted by TuxFamily administrators <adm@staff.tuxfamily.org>
@@ -11919,9 +13792,18 @@ syno-ds.de
 synology-diskstation.de
 synology-ds.de
 
+// Typedream : https://typedream.com
+// Submitted by Putri Karunia <putri@typedream.com>
+typedream.app
+
+// Typeform : https://www.typeform.com
+// Submitted by Sergi Ferriz <sergi.ferriz@typeform.com>
+pro.typeform.com
+
 // Uberspace : https://uberspace.de
 // Submitted by Moritz Werner <mwerner@jonaspasche.com>
 uber.space
+*.uberspace.de
 
 // UDR Limited : http://www.udr.hk.com
 // Submitted by registry <hostmaster@udr.hk.com>
@@ -11930,25 +13812,191 @@ hk.org
 ltd.hk
 inc.hk
 
+// United Gameserver GmbH : https://united-gameserver.de
+// Submitted by Stefan Schwarz <sysadm@united-gameserver.de>
+virtualuser.de
+virtual-user.de
+
+// Upli : https://upli.io
+// Submitted by Lenny Bakkalian <lenny.bakkalian@gmail.com>
+upli.io
+
+// urown.net : https://urown.net
+// Submitted by Hostmaster <hostmaster@urown.net>
+urown.cloud
+dnsupdate.info
+
 // .US
 // Submitted by Ed Moore <Ed.Moore@lib.de.us>
 lib.de.us
+
+// VeryPositive SIA : http://very.lv
+// Submitted by Danko Aleksejevs <danko@very.lv>
+2038.io
+
+// Vercel, Inc : https://vercel.com/
+// Submitted by Connor Davis <security@vercel.com>
+vercel.app
+vercel.dev
+now.sh
 
 // Viprinet Europe GmbH : http://www.viprinet.com
 // Submitted by Simon Kissel <hostmaster@viprinet.com>
 router.management
 
+// Virtual-Info : https://www.virtual-info.info/
+// Submitted by Adnan RIHAN <hostmaster@v-info.info>
+v-info.info
+
+// Voorloper.com: https://voorloper.com
+// Submitted by Nathan van Bakel <info@voorloper.com>
+voorloper.cloud
+
+// Voxel.sh DNS : https://voxel.sh/dns/
+// Submitted by Mia Rehlinger <dns@voxel.sh>
+neko.am
+nyaa.am
+be.ax
+cat.ax
+es.ax
+eu.ax
+gg.ax
+mc.ax
+us.ax
+xy.ax
+nl.ci
+xx.gl
+app.gp
+blog.gt
+de.gt
+to.gt
+be.gy
+cc.hn
+blog.kg
+io.kg
+jp.kg
+tv.kg
+uk.kg
+us.kg
+de.ls
+at.md
+de.md
+jp.md
+to.md
+indie.porn
+vxl.sh
+ch.tc
+me.tc
+we.tc
+nyan.to
+at.vg
+blog.vu
+dev.vu
+me.vu
+
+// V.UA Domain Administrator : https://domain.v.ua/
+// Submitted by Serhii Rostilo <sergey@rostilo.kiev.ua>
+v.ua
+
+// Vultr Objects : https://www.vultr.com/products/object-storage/
+// Submitted by Niels Maumenee <storage@vultr.com>
+*.vultrobjects.com
+
+// Waffle Computer Inc., Ltd. : https://docs.waffleinfo.com
+// Submitted by Masayuki Note <masa@blade.wafflecell.com>
+wafflecell.com
+
+// WebHare bv: https://www.webhare.com/
+// Submitted by Arnold Hendriks <info@webhare.com>
+*.webhare.dev
+
+// WebHotelier Technologies Ltd: https://www.webhotelier.net/
+// Submitted by Apostolos Tsakpinis <apostolos.tsakpinis@gmail.com>
+reserve-online.net
+reserve-online.com
+bookonline.app
+hotelwithflight.com
+
+// WeDeploy by Liferay, Inc. : https://www.wedeploy.com
+// Submitted by Henrique Vicente <security@wedeploy.com>
+wedeploy.io
+wedeploy.me
+wedeploy.sh
+
 // Western Digital Technologies, Inc : https://www.wdc.com
 // Submitted by Jung Jin <jungseok.jin@wdc.com>
 remotewd.com
 
+// WIARD Enterprises : https://wiardweb.com
+// Submitted by Kidd Hustle <kiddhustle@wiardweb.com>
+pages.wiardweb.com
+
 // Wikimedia Labs : https://wikitech.wikimedia.org
-// Submitted by Yuvi Panda <yuvipanda@wikimedia.org>
+// Submitted by Arturo Borrero Gonzalez <aborrero@wikimedia.org>
 wmflabs.org
+toolforge.org
+wmcloud.org
+
+// WISP : https://wisp.gg
+// Submitted by Stepan Fedotov <stepan@wisp.gg>
+panel.gg
+daemon.panel.gg
+
+// Wizard Zines : https://wizardzines.com
+// Submitted by Julia Evans <julia@wizardzines.com>
+messwithdns.com
+
+// WoltLab GmbH : https://www.woltlab.com
+// Submitted by Tim Düsterhus <security@woltlab.cloud>
+woltlab-demo.com
+myforum.community
+community-pro.de
+diskussionsbereich.de
+community-pro.net
+meinforum.net
+
+// Woods Valldata : https://www.woodsvalldata.co.uk/
+// Submitted by Chris Whittle <chris.whittle@woodsvalldata.co.uk>
+affinitylottery.org.uk
+raffleentry.org.uk
+weeklylottery.org.uk
+
+// WP Engine : https://wpengine.com/
+// Submitted by Michael Smith <michael.smith@wpengine.com>
+// Submitted by Brandon DuRette <brandon.durette@wpengine.com>
+wpenginepowered.com
+js.wpenginepowered.com
+
+// Wix.com, Inc. : https://www.wix.com
+// Submitted by Shahar Talmi <shahar@wix.com>
+wixsite.com
+editorx.io
+
+// XenonCloud GbR: https://xenoncloud.net
+// Submitted by Julian Uphoff <publicsuffixlist@xenoncloud.net>
+half.host
+
+// XnBay Technology : http://www.xnbay.com/
+// Submitted by XnBay Developer <developer.xncloud@gmail.com>
+xnbay.com
+u2.xnbay.com
+u2-local.xnbay.com
 
 // XS4ALL Internet bv : https://www.xs4all.nl/
 // Submitted by Daniel Mostertman <unixbeheer+publicsuffix@xs4all.net>
+cistron.nl
+demon.nl
 xs4all.space
+
+// Yandex.Cloud LLC: https://cloud.yandex.com
+// Submitted by Alexander Lodin <security+psl@yandex-team.ru>
+yandexcloud.net
+storage.yandexcloud.net
+website.yandexcloud.net
+
+// YesCourse Pty Ltd : https://yescourse.com
+// Submitted by Atul Bhouraskar <atul@yescourse.com>
+official.academy
 
 // Yola : https://www.yola.com/
 // Submitted by Stefano Rivera <stefano@yola.com>
@@ -11964,19 +14012,25 @@ ybo.review
 ybo.science
 ybo.trade
 
+// Yunohost : https://yunohost.org
+// Submitted by Valentin Grimaud <security@yunohost.org>
+ynh.fr
+nohost.me
+noho.st
+
 // ZaNiC : http://www.za.net/
 // Submitted by registry <hostmaster@nic.za.net>
 za.net
 za.org
 
-// Zeit, Inc. : https://zeit.domains/
-// Submitted by Olli Vanhoja <olli@zeit.co>
-now.sh
+// Zine EOOD : https://zine.bg/
+// Submitted by Martin Angelov <martin@zine.bg>
+bss.design
 
-// 1GB LLC : https://www.1gb.ua/
-// Submitted by 1GB LLC <noc@1gb.com.ua>
-cc.ua
-inf.ua
-ltd.ua
+// Zitcom A/S : https://www.zitcom.dk
+// Submitted by Emil Stahl <esp@zitcom.dk>
+basicserver.io
+virtualserver.io
+enterprisecloud.nu
 
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
In some network restricted environments it will be great to have a way to disable the autoupdate.

This small fix adds a check. If there is an environment variable `FASTTLD_NO_AUTO_UPDATE=1`  then it skips the update.