### PR TITLE
Add FASTTLD_NO_AUTO_UPDATE flag and fix bug with null bytes input.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ or
 >>> FastTLDExtract().update()
 ```
 
+This option can be disabled setting the environment flag `FASTTLD_NO_AUTO_UPDATE` to `1`.
+
+
 ## Specify Mozilla Public Suffix List file
 
 You can also specify your own public suffix list file.

--- a/fasttld/FastTLDExtract.py
+++ b/fasttld/FastTLDExtract.py
@@ -31,7 +31,7 @@ def looks_like_ip(maybe_ip):
         return True
     except socket.error:  # for Python 2 compatibility
         pass
-    except (AttributeError, UnicodeError):
+    except (AttributeError, UnicodeError, ValueError):
         if IP_RE.match(maybe_ip):
             return True
 

--- a/fasttld/psl.py
+++ b/fasttld/psl.py
@@ -8,6 +8,7 @@
 Copyright (c) 2022 Wu Tingfeng
 Copyright (c) 2017-2018 Jophy
 """
+import os
 import os.path
 import time
 
@@ -91,6 +92,8 @@ def auto_update():
     This function will update public_suffix_list.dat file every 3 days.
     :return:
     """
+    if os.environ.get("FASTTLD_NO_AUTO_UPDATE") == "1":
+        return
     need_update = False
     file_path = os.path.dirname(os.path.realpath(__file__)) + "/public_suffix_list.dat"
     if os.path.isfile(file_path):

--- a/tests/maintest.py
+++ b/tests/maintest.py
@@ -262,6 +262,10 @@ class FastTLDExtractCase(unittest.TestCase):
             all_suffix_asserts[3],
         )
 
+    def test_random_text(self):
+        self.assertEqual(all_suffix.extract("this is a text without a domain"), ("", "", "", "", "", "", "", ""))
+        self.assertEqual(all_suffix.extract("Null byte\x00string"), ("", "", "", "", "", "", "", ""))
+
     def test_nested_dict(self):
         d = {}
         all_suffix.nested_dict(d, keys=["ac"])


### PR DESCRIPTION
Add the FASTTLD_NO_AUTO_UPDATE flag again #5.
Fixed a small bug if there is a null byte `\x00` in the input.