### PR TITLE
Return namedtuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ or
 >>> FastTLDExtract().update()
 ```
 
+This option can be disabled setting the environment flag `FASTTLD_NO_AUTO_UPDATE` to `1`.
+
+
 ## Specify Mozilla Public Suffix List file
 
 You can also specify your own public suffix list file.

--- a/fasttld/FastTLDExtract.py
+++ b/fasttld/FastTLDExtract.py
@@ -10,6 +10,7 @@ Copyright (c) 2017-2018 Jophy
 """
 import re
 import socket
+from collections import namedtuple
 
 import idna
 
@@ -22,6 +23,20 @@ IP_RE = re.compile(
 
 # Characters valid in scheme names
 SCHEME_RE = re.compile(r"^[A-Za-z0-9+-.]+://")
+
+TLDResult = namedtuple(
+    "TLDResult",
+    [
+        "scheme",
+        "userinfo",
+        "subdomain",
+        "domain",
+        "suffix",
+        "port",
+        "path",
+        "domain_name",
+    ],
+)
 
 
 def looks_like_ip(maybe_ip):
@@ -104,12 +119,12 @@ class FastTLDExtract(object):
         :param raw_url:
         :param subdomain: Output options. This option will reduce efficiency. Maybe 10%
         :param format: To format raw_url string.
-        :return: Tuple(subdomain, domain, suffix, domain_name)
+        :return: NamedTuple(scheme, userinfo, subdomain, domain, suffix, port, path, domain_name)
         >>> FastTLDExtract.extract('www.google.com.hk', subdomain=True)
-        >>> ('www', 'google', 'com.hk', 'google.com.hk')
+        >>> TLDResult(scheme='', userinfo='', subdomain='www', domain='google', suffix='com.hk', port='', path='', domain_name='google.com.hk')
 
         >>> FastTLDExtract.extract('127.0.0.1', subdomain=True)
-        >>> ('', '127.0.0.1', '', '127.0.0.1')
+        >>> TLDResult(scheme='', userinfo='', subdomain='', domain='127.0.0.1', suffix='', port='', path='', domain_name='127.0.0.1')
         """
         ret_scheme = ret_userinfo = ret_subdomain = ret_domain = ""
         ret_suffix = ret_port = ret_path = ret_domain_name = ""
@@ -166,7 +181,16 @@ class FastTLDExtract(object):
 
         # Determine if raw_url is an IP address
         if len(netloc) != 0 and looks_like_ip(netloc):
-            return ("", netloc, "", netloc)
+            return TLDResult(
+                "",
+                "",
+                "",
+                netloc,
+                "",
+                "",
+                "",
+                netloc
+            )
 
         labels = netloc.split(".")
         labels.reverse()
@@ -218,8 +242,16 @@ class FastTLDExtract(object):
         if ret_domain and ret_suffix:
             ret_domain_name = "%s.%s" % (ret_domain, ret_suffix)
 
-        return (ret_scheme, ret_userinfo, ret_subdomain, ret_domain,
-                ret_suffix, ret_port, ret_path, ret_domain_name)
+        return TLDResult(
+            ret_scheme,
+            ret_userinfo,
+            ret_subdomain,
+            ret_domain,
+            ret_suffix,
+            ret_port,
+            ret_path,
+            ret_domain_name,
+        )
 
     def format(self, raw_url):
         """

--- a/fasttld/FastTLDExtract.py
+++ b/fasttld/FastTLDExtract.py
@@ -31,7 +31,7 @@ def looks_like_ip(maybe_ip):
         return True
     except socket.error:  # for Python 2 compatibility
         pass
-    except (AttributeError, UnicodeError):
+    except (AttributeError, UnicodeError, ValueError):
         if IP_RE.match(maybe_ip):
             return True
 

--- a/fasttld/psl.py
+++ b/fasttld/psl.py
@@ -8,6 +8,7 @@
 Copyright (c) 2022 Wu Tingfeng
 Copyright (c) 2017-2018 Jophy
 """
+import os
 import os.path
 import time
 
@@ -91,6 +92,8 @@ def auto_update():
     This function will update public_suffix_list.dat file every 3 days.
     :return:
     """
+    if os.environ.get("FASTTLD_NO_AUTO_UPDATE") == "1":
+        return
     need_update = False
     file_path = os.path.dirname(os.path.realpath(__file__)) + "/public_suffix_list.dat"
     if os.path.isfile(file_path):

--- a/tests/maintest.py
+++ b/tests/maintest.py
@@ -262,6 +262,10 @@ class FastTLDExtractCase(unittest.TestCase):
             all_suffix_asserts[3],
         )
 
+    def test_random_text(self):
+        self.assertEqual(all_suffix.extract("this is a text without a domain"), ("", "", "", "", "", "", "", ""))
+        self.assertEqual(all_suffix.extract("Null byte\x00string"), ("", "", "", "", "", "", "", ""))
+
     def test_nested_dict(self):
         d = {}
         all_suffix.nested_dict(d, keys=["ac"])


### PR DESCRIPTION
Since the last version, the return type of the `extract()` method went from 4 to 8 items. 

I think using a `namedtuple` allows the user to use both index (`result[0]`) and dot (`result.domain`) notations. Improving readability, but without affecting the performance.

PS: This includes the `FASTTLD_NO_AUTO_UPDATE` changes because I used that as my main branch, but it's unrelated.